### PR TITLE
Update docs, follow rust convention, run rustfmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,92 +1,119 @@
 //! # gettext C library FFI binding for Rust
-
+//!
 //! Usage:
 //!
-//!```
+//! ```
 //! use gettext_rs::*;
-//! setlocale(LocaleCategory::LC_ALL, "en_US.UTF-8");
-//! bindtextdomain("hellorust", "/usr/local/share/locale");
-//! textdomain("hellorust");
-//! println!("Translated: {}", gettext("Hello, world!"));
-//!```
+//!
+//! set_locale(LocaleCategory::LcAll, "en_US.UTF-8");
+//!
+//! bind_text_domain("hellorust", "/usr/local/share/locale");
+//! text_domain("hellorust");
+//!
+//! println!("Translated: {}", get_text("Hello, world!"));
+//! ```
 
 /// Raw FFI interface for gettext library
 mod gettext_raw {
-	use std::os::raw::{c_char, c_int};
+    use std::os::raw::{c_char, c_int};
 
-	extern {
-	    pub fn gettext(s: *const c_char) -> *const c_char;
-	    pub fn bindtextdomain(domain : *const c_char, dir : *const c_char) -> *const c_char;
-	    pub fn textdomain(domain : *const c_char) -> *const c_char;
-	    pub fn setlocale(category: c_int, locale: *const c_char) -> *const c_char;
-	}
+    extern "C" {
+        pub fn gettext(s: *const c_char) -> *const c_char;
+        pub fn bindtextdomain(domain: *const c_char, dir: *const c_char) -> *const c_char;
+        pub fn textdomain(domain: *const c_char) -> *const c_char;
+        pub fn setlocale(category: c_int, locale: *const c_char) -> *const c_char;
+    }
 }
 
 /// Safe wrapper for gettext library
-mod gettext {
-	use gettext_raw;
-	use std::ffi::CString;
-	use std::ffi::CStr;
+mod get_text {
+    use gettext_raw;
+    use std::ffi::CString;
+    use std::ffi::CStr;
 
-	/// Locale category enum ported from locale.h
-	pub enum LocaleCategory {
-		LC_CTYPE               = 0,
-		LC_NUMERIC             = 1,
-		LC_TIME                = 2,
-		LC_COLLATE             = 3,
-		LC_MONETARY            = 4,
-		LC_MESSAGES            = 5,
-		LC_ALL                 = 6,
-		LC_PAPER               = 7,
-		LC_NAME                = 8,
-		LC_ADDRESS             = 9,
-		LC_TELEPHONE           = 10,
-		LC_MEASUREMENT         = 11,
-		LC_IDENTIFICATION      = 12		
-	}
+    /// Locale category enum ported from locale.h
+    pub enum LocaleCategory {
+        /// Character classification and case conversion.
+        LcCType = 0,
+        /// Non-monetary numeric formats.
+        LcNumeric = 1,
+        /// Date and time formats.
+        LcTime = 2,
+        /// Collation order.
+        LcCollate = 3,
+        /// Monetary formats.
+        LcMonetary = 4,
+        /// Formats of informative and diagnostic messages and interactive responses.
+        LcMessages = 5,
+        /// For all.
+        LcAll = 6,
+        /// Paper size.
+        LcPaper = 7,
+        /// Name formats.
+        LcName = 8,
+        /// Address formats and location information.
+        LcAddress = 9,
+        /// Telephone number formats.
+        LcTelephone = 10,
+        /// Measurement units (Metric or Other).
+        LcMeasurement = 11,
+        /// Metadata about the locale information.
+        LcIdentification = 12,
+    }
 
-
-	/// Translate msgid to localized message	
-	pub fn gettext<T: Into<Vec<u8>>>(s:T) -> String {
-		unsafe {
-			CStr::from_ptr(gettext_raw::gettext(CString::new(s).unwrap().as_ptr())).to_string_lossy().into_owned()
-		}
-	}
-
-	/// Switch to specific text domain
-	pub fn textdomain<T: Into<Vec<u8>>>(domain:T) -> String {
-		unsafe {
-			CStr::from_ptr(gettext_raw::textdomain(CString::new(domain).unwrap().as_ptr())).to_string_lossy().into_owned()
-		}
-	}
-	
-	/// Bind text domain to some directory containing gettext MO files
-	pub fn bindtextdomain<T: Into<Vec<u8>>>(domian:T, dir:T) -> String {
-                unsafe {
-                	CStr::from_ptr(gettext_raw::bindtextdomain(CString::new(domian).unwrap().as_ptr(), CString::new(dir).unwrap().as_ptr())).to_string_lossy().into_owned()
-		}
+    /// Translate msgid to localized message
+    pub fn get_text<T: Into<Vec<u8>>>(s: T) -> String {
+        unsafe {
+            CStr::from_ptr(gettext_raw::gettext(CString::new(s).unwrap().as_ptr()))
+                .to_string_lossy()
+                .into_owned()
         }
+    }
 
-	/// Set current locale for translations
-	pub fn setlocale<T: Into<Vec<u8>>>(category: LocaleCategory, locale:T) -> String {
-                unsafe {
-                        CStr::from_ptr(gettext_raw::setlocale(category as i32, CString::new(locale).unwrap().as_ptr())).to_string_lossy().into_owned()
-                }
+    /// Switch to specific text domain
+    pub fn text_domain<T: Into<Vec<u8>>>(domain: T) -> String {
+        unsafe {
+            CStr::from_ptr(gettext_raw::textdomain(CString::new(domain).unwrap().as_ptr()))
+                .to_string_lossy()
+                .into_owned()
         }
+    }
+
+    /// Bind text domain to some directory containing gettext MO files
+    pub fn bind_text_domain<T: Into<Vec<u8>>>(domian: T, dir: T) -> String {
+        unsafe {
+            CStr::from_ptr(gettext_raw::bindtextdomain(CString::new(domian).unwrap().as_ptr(),
+                                                       CString::new(dir).unwrap().as_ptr()))
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
+
+    /// Set current locale for translations
+    pub fn set_locale<T: Into<Vec<u8>>>(category: LocaleCategory, locale: T) -> String {
+        unsafe {
+            CStr::from_ptr(gettext_raw::setlocale(category as i32,
+                                                  CString::new(locale).unwrap().as_ptr()))
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
 
 }
 
-pub use gettext::*;
+pub use get_text::*;
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn smoke_test() {
-	    setlocale(LocaleCategory::LC_ALL, "en_US.UTF-8");
-	    bindtextdomain("hellorust", "/usr/local/share/locale");
-	    textdomain("hellorust");
-	    assert_eq!("Hello, world!", gettext("Hello, world!"));
-	}
+    #[test]
+    fn smoke_test() {
+        set_locale(LocaleCategory::LcAll, "en_US.UTF-8");
+
+        bind_text_domain("hellorust", "/usr/local/share/locale");
+        text_domain("hellorust");
+
+        assert_eq!("Hello, world!", get_text("Hello, world!"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@
 //! ```
 //! use gettext_rs::*;
 //!
-//! set_locale(LocaleCategory::LcAll, "en_US.UTF-8");
+//! setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 //!
-//! bind_text_domain("hellorust", "/usr/local/share/locale");
-//! text_domain("hellorust");
+//! bindtextdomain("hellorust", "/usr/local/share/locale");
+//! textdomain("hellorust");
 //!
-//! println!("Translated: {}", get_text("Hello, world!"));
+//! println!("Translated: {}", gettext("Hello, world!"));
 //! ```
 
 /// Raw FFI interface for gettext library
@@ -26,7 +26,7 @@ mod gettext_raw {
 }
 
 /// Safe wrapper for gettext library
-mod get_text {
+mod gettext {
     use gettext_raw;
     use std::ffi::CString;
     use std::ffi::CStr;
@@ -62,7 +62,7 @@ mod get_text {
     }
 
     /// Translate msgid to localized message
-    pub fn get_text<T: Into<Vec<u8>>>(s: T) -> String {
+    pub fn gettext<T: Into<Vec<u8>>>(s: T) -> String {
         unsafe {
             CStr::from_ptr(gettext_raw::gettext(CString::new(s).unwrap().as_ptr()))
                 .to_string_lossy()
@@ -71,7 +71,7 @@ mod get_text {
     }
 
     /// Switch to specific text domain
-    pub fn text_domain<T: Into<Vec<u8>>>(domain: T) -> String {
+    pub fn textdomain<T: Into<Vec<u8>>>(domain: T) -> String {
         unsafe {
             CStr::from_ptr(gettext_raw::textdomain(CString::new(domain).unwrap().as_ptr()))
                 .to_string_lossy()
@@ -80,7 +80,7 @@ mod get_text {
     }
 
     /// Bind text domain to some directory containing gettext MO files
-    pub fn bind_text_domain<T: Into<Vec<u8>>>(domian: T, dir: T) -> String {
+    pub fn bindtextdomain<T: Into<Vec<u8>>>(domian: T, dir: T) -> String {
         unsafe {
             CStr::from_ptr(gettext_raw::bindtextdomain(CString::new(domian).unwrap().as_ptr(),
                                                        CString::new(dir).unwrap().as_ptr()))
@@ -90,7 +90,7 @@ mod get_text {
     }
 
     /// Set current locale for translations
-    pub fn set_locale<T: Into<Vec<u8>>>(category: LocaleCategory, locale: T) -> String {
+    pub fn setlocale<T: Into<Vec<u8>>>(category: LocaleCategory, locale: T) -> String {
         unsafe {
             CStr::from_ptr(gettext_raw::setlocale(category as i32,
                                                   CString::new(locale).unwrap().as_ptr()))
@@ -101,7 +101,7 @@ mod get_text {
 
 }
 
-pub use get_text::*;
+pub use gettext::*;
 
 #[cfg(test)]
 mod tests {
@@ -109,11 +109,11 @@ mod tests {
 
     #[test]
     fn smoke_test() {
-        set_locale(LocaleCategory::LcAll, "en_US.UTF-8");
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bind_text_domain("hellorust", "/usr/local/share/locale");
-        text_domain("hellorust");
+        bindtextdomain("hellorust", "/usr/local/share/locale");
+        textdomain("hellorust");
 
-        assert_eq!("Hello, world!", get_text("Hello, world!"));
+        assert_eq!("Hello, world!", gettext("Hello, world!"));
     }
 }


### PR DESCRIPTION
* Added docs for `LocaleCategory` enum (taken from `man locale`)
* Ran `rustfmt` on the code
* Changed function names and enum variants to Rust conventions (snake case names).

Code compiles w/o warnings now (yay!)

If you don't like the changes made by `rustfmt`, I can revert it back =) 

You can update the docs at gh-pages.