### PR TITLE
Build on Windows + GNU (e.g. MSYS2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ be configured via environment variables:
   GETTEXT_STATIC - If specified, gettext libraries will be statically rather than dynamically linked.
 
 For target-specific configuration, each of these environment variables can be prefixed by an upper-cased target, for example, X86_64_UNKNOWN_LINUX_GNU_GETTEXT_DIR. This can be useful in cross compilation contexts.
+
+Note: on Windows + GNU, if you want to build `gettext-rs` with its own static
+version of `getttext`, install the following packages first:
+```
+pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc libxml2-devel tar
+```
+
+The build is quite long. You can speed things up by setting (e.g. for 4 cores):
+```
+export NUM_JOBS=5
+```
+
+This doesn't work on AppVeyor ATM. Use `SET GETTEXT_SYSTEM=true` instead.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gettext.rs's build script will by default build its own version of gettext and
 statically link against that. If that is not what you want the build script can
 be configured via environment variables:
 
-  GETTEXT_SYSTEM - If specified gettext-sys uses the gettext that is part of glibc. This only works on linux
+  GETTEXT_SYSTEM - If specified gettext-sys uses the gettext that is part of glibc. This only works on linux and Windows + GNU (e.g. [MSYS2](http://www.msys2.org/)). On Windows, you will need to install `gettext-devel`.
 
   GETTEXT_DIR - If specified, a directory that will be used to find gettext installation. It's expected that under this directory the include folder has header files, the bin folder has gettext binary and a lib folder has the runtime libraries.
 

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -3,7 +3,7 @@ extern crate cc;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::io::ErrorKind;
 
@@ -40,6 +40,23 @@ fn get_windows_gnu_root() -> String {
     }).unwrap_or_else(||
         fail("Failed to get gnu installation root dir")
     )
+}
+
+fn posix_path(path: &Path) -> String {
+    let path = path
+        .to_str()
+        .unwrap_or_else(|| fail(&format!("Couldn't convert path {:?} to string", path)));
+    if env::var("HOST").unwrap().contains("windows") {
+        let path = path.replace("\\", "/");
+        if path.find(":") == Some(1) {
+            // absolute path with a drive letter
+            format!("/{}{}", &path[0..1], &path[2..])
+        } else {
+            path.to_owned()
+        }
+    } else {
+        path.to_owned()
+    }
 }
 
 fn main() {
@@ -130,13 +147,22 @@ fn main() {
         cflags.push(" ");
     }
 
-    if !dst.join("gettext/configure").is_file() {
+    if target.contains("windows") {
+        // Avoid undefined reference to `__imp_xmlFree'
+        cflags.push("-DLIBXML_STATIC");
+    }
+
+    if !dst.join("gettext").join("configure").is_file() {
         let mut cmd = Command::new("tar");
         cmd.current_dir(&dst.join("gettext"))
-           .arg("xvf")
+           .arg("xf")
            .arg(&src.join("gettext-0.19.8.1.tar.gz"))
            .arg("--strip-components")
            .arg("1");
+        if host.contains("windows") {
+            // tar confuses local path with a remote resource because of ':'
+            cmd.arg("--force-local");
+        }
         run(&mut cmd, "tar");
     }
 
@@ -146,7 +172,7 @@ fn main() {
        .env("LD", &which("ld").unwrap())
        .env("VERBOSE", "1")
        .current_dir(&dst.join("build"))
-       .arg(&dst.join("gettext/configure"));
+       .arg(&posix_path(&dst.join("gettext").join("configure")));
 
     cmd.arg("--without-emacs");
     cmd.arg("--disable-java");
@@ -160,7 +186,13 @@ fn main() {
     cmd.arg("--with-included-libcroco");
     cmd.arg("--with-included-libunistring");
 
-    cmd.arg(format!("--prefix={}", dst.to_str().unwrap().to_string()));
+    if target.contains("windows") {
+        // FIXME: should pthread support be optional?
+        // It is needed by `cargo test` while generating doc
+        cmd.arg("--enable-threads=windows");
+    }
+
+    cmd.arg(format!("--prefix={}", &posix_path(&dst)));
 
     if target != host &&
        (!target.contains("windows") || !host.contains("windows")) {
@@ -193,6 +225,11 @@ fn main() {
     println!("cargo:include={}/include", dst.display());
     println!("cargo:bin={}/bin", dst.display());
     println!("cargo:root={}", dst.display());
+
+    if target.contains("windows") {
+        println!("cargo:rustc-link-search=native={}/lib", &get_windows_gnu_root());
+        println!("cargo:rustc-link-lib=dylib=iconv");
+    }
 }
 
 fn run(cmd: &mut Command, program: &str) {

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -17,7 +17,9 @@ fn main() {
     // Skip ptr check because the symbol name is different between glibc
     // implementation and static lib.
     // eg. gettext is libintl_gettext in static lib
-    if env::var_os("GETTEXT_SYSTEM").is_none() {
+    if env::var_os("GETTEXT_SYSTEM").is_none()
+        || env::var("TARGET").unwrap().contains("windows")
+    {
         println!("Skipping ptr check");
         cfg.skip_fn_ptrcheck(|_| true);
     }


### PR DESCRIPTION
Add support for building on Windows + GNU. At the moment, this has been tested on a fresh install of MSYS2 in both system's `gettext` and internal static builds variants.

On AppVeyor, [internal static build fails](https://ci.appveyor.com/project/fengalin/media-toc/build/1.0.335/job/ax0b0ml4an0y1l6i) due to `make` not being able to find `libgnuintl.h` and `libintl.h`. I don't know how to solve this, so I recommend using system's `gettext` on this environment. Due to the long build time with the internal static `gettext` on Windows, it seems preferable anyway.