### PR TITLE
Add a `gettext-system` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT"
 [lib]
 name = "gettextrs"
 
+[features]
+gettext-system = ["gettext-sys/gettext-system"]
+
 [dependencies.gettext-sys]
 version = "0.19.8"
 path = "gettext-sys"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ statically link against that. If that is not what you want the build script can
 be configured via environment variables:
 
   GETTEXT_SYSTEM - If specified gettext-sys uses the gettext that is part of glibc. This only works on linux and Windows + GNU (e.g. [MSYS2](http://www.msys2.org/)). On Windows, you will need to install `gettext-devel`.
+  You can also activate the `gettext-system` feature from your `Cargo.toml` configuration:
+  ``` toml
+  gettext-rs = { git = "https://github.com/Koka/gettext-rs", features = ["gettext-system"] }
+  ```
 
   GETTEXT_DIR - If specified, a directory that will be used to find gettext installation. It's expected that under this directory the include folder has header files, the bin folder has gettext binary and a lib folder has the runtime libraries.
 

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -10,5 +10,8 @@ links = "gettext"
 [lib]
 path = "lib.rs"
 
+[features]
+gettext-system = []
+
 [build-dependencies]
 cc = "1.0"

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -62,7 +62,7 @@ fn posix_path(path: &Path) -> String {
 fn main() {
     let target = env::var("TARGET").unwrap();
 
-    if env("GETTEXT_SYSTEM").is_some() {
+    if cfg!(feature = "gettext-system") || env("GETTEXT_SYSTEM").is_some() {
         if target.contains("linux") && target.contains("-gnu") {
             // intl is part of glibc
             return;


### PR DESCRIPTION
Add the `gettext-system` feature in order to activate building against the
system's `gettext` without the need to set an environment variable.