### PR TITLE
TextDomain: use `unwrap` instead of `ok` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use gettextrs::TextDomain;
 
 TextDomain::new("hellorust")
            .init()
-           .ok();
+           .unwrap();
 ```
 
 ## Manual configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! TextDomain::new("hellorust")
 //!            .init()
-//!            .ok();
+//!            .unwrap();
 //! ```
 //!
 //! [`TextDomain`]: struct.TextDomain.html

--- a/src/text_domain.rs
+++ b/src/text_domain.rs
@@ -56,7 +56,7 @@ pub enum TextDomainError {
 ///
 /// TextDomain::new("my_textdomain")
 ///            .init()
-///            .ok();
+///            .unwrap();
 /// ```
 ///
 /// Use the translation in current language under the `target` directory if available, otherwise
@@ -68,7 +68,7 @@ pub enum TextDomainError {
 /// TextDomain::new("my_textdomain")
 ///            .prepend("target")
 ///            .init()
-///            .ok();
+///            .unwrap();
 /// ```
 ///
 /// Scan the `target` directory only, force locale to `fr_FR` and handle errors:
@@ -244,7 +244,7 @@ impl TextDomain {
     ///
     /// TextDomain::new("my_textdomain")
     ///            .init()
-    ///            .ok();
+    ///            .unwrap();
     /// ```
     ///
     /// [`TextDomainError`]: enum.TextDomainError.html


### PR DESCRIPTION
Sorry for the noise... I just realized it made more sense using `unwrap` in the examples.