### PR TITLE
Use musl's gettext support with GETTEXT_SYSTEM

### DIFF
--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -63,8 +63,8 @@ fn main() {
     let target = env::var("TARGET").unwrap();
 
     if cfg!(feature = "gettext-system") || env("GETTEXT_SYSTEM").is_some() {
-        if target.contains("linux") && target.contains("-gnu") {
-            // intl is part of glibc
+        if target.contains("linux") && (target.contains("-gnu") || target.contains("-musl")) {
+            // intl is part of glibc and musl
             return;
         } else if target.contains("windows") && target.contains("-gnu") {
             // gettext doesn't come with a pkg-config file


### PR DESCRIPTION
Musl's gettext support is in somewhat good shape now, so we can use it instead
of GNU gettext

fixes #14