### PR TITLE
derive Clone and Copy for LocaleCategory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod text_domain;
 pub use text_domain::{TextDomain, TextDomainError};
 
 /// Locale category enum ported from locale.h
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum LocaleCategory {
     /// Character classification and case conversion.
     LcCType = 0,


### PR DESCRIPTION
I'm facing an issue because I'm storing the category in a struct but then when I want to pass it to the function I cannot because it's moved by default and I cannot clone it either.

Would it be okay for you to make derive from Clone and from Copy?