### PR TITLE
Travis: avoid exceeding log length limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 script:
   - cargo generate-lockfile
   - cargo generate-lockfile --manifest-path systest/Cargo.toml
+  - export TERM=dumb # Disable progress bar in Cargo. This cuts down on output, avoiding Travis' log length limits.
   - if [ -z "$DOCKER" ]; then
       sh ci/run.sh;
     else
@@ -60,6 +61,7 @@ script:
         -e NO_RUN
         -e GETTEXT_SYSTEM
         -e CARGO_TARGET_DIR=/src/target
+        -e TERM
         -it rust
         sh ci/run.sh;
     fi


### PR DESCRIPTION
Two Travis jobs currently fail because their output exceeds log length limit:

- https://travis-ci.org/github/Koka/gettext-rs/jobs/653263406#L24922
- https://travis-ci.org/github/Koka/gettext-rs/jobs/653263407#L24908

By `diff`ing the output with the last passing job, https://travis-ci.org/github/Koka/gettext-rs/jobs/417123508, I found that Cargo now prints out a progress bar. Travis stores each update of the progress bar as a separate line in the log, which eventually reaches the limit.

This is a known problem (https://github.com/rust-lang/cargo/issues/5721), and I applied the suggested solution, which is: set `TERM` environment variable to `dumb` to disable the progress bar. I believe this won't affect the usefulness of the output.