### PR TITLE
Dependency check to build GNU gettext

### DIFF
--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -61,9 +61,9 @@ fn posix_path(path: &Path) -> String {
 
 fn check_dependencies(required_programs: Vec<&str>) {
     let command = |x| { 
-        let status = Command::new("command")
-            .arg("-v")
-            .arg(x)
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {}", x))
             .status()
             .expect("failed to excute process");
         
@@ -109,7 +109,7 @@ fn main() {
     }
 
     // Programs required to compile GNU gettext
-    check_dependencies(vec!["cmp", "diff", "find", "gcc", "xz"]);
+    check_dependencies(vec!["cmp", "diff", "find", "xz"]);
 
     if let Some(gettext_dir) = env("GETTEXT_DIR") {
         println!("cargo:root={}", gettext_dir);

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -59,6 +59,28 @@ fn posix_path(path: &Path) -> String {
     }
 }
 
+fn check_dependencies(required_programs: Vec<&str>) {
+    let command = |x| { 
+        let status = Command::new("command")
+            .arg("-v")
+            .arg(x)
+            .status()
+            .expect("failed to excute process");
+        
+        if status.success() {
+            "".to_owned()
+        } else {
+            format!(" {},", x)
+        }      
+    };
+
+    let errors: String = required_programs.iter().map(|x| command(x)).collect();
+    
+    if !errors.is_empty() {
+        fail(&format!("The following programs were not found:{}", errors));
+    }
+}
+
 fn main() {
     let target = env::var("TARGET").unwrap();
 
@@ -85,6 +107,9 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=dylib=iconv");
     }
+
+    // Programs required to compile GNU gettext
+    check_dependencies(vec!["cmp", "diff", "find", "gcc", "xz"]);
 
     if let Some(gettext_dir) = env("GETTEXT_DIR") {
         println!("cargo:root={}", gettext_dir);


### PR DESCRIPTION
I was having trouble reproducing a build on GNOME's Gitlab instance. The reason for the failed builds was because I was using the latest Fedora Docker image, while my computer has the latest Fedora Workstation image. For some reason the Fedora Docker image did not come with some of the basic programs the C gettext code requires to compile. It took me a long time* to sift through the output to figure out the issues were caused by missing CLI programs.

This PR adds a check to determine if the required programs are on the machine, or fails the build with a clean panic message. I checked the added code works on my machine, but I did not check if it'll work on another OS or Github's Actions.

[My Gitlab CI yml file](https://gitlab.gnome.org/dleggo/recipes/-/blob/rust-port/.gitlab-ci.yml)
\*maybe because I'm new to programming