### PR TITLE
Use newer macOS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,11 @@ matrix:
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu DOCKER=linux64-build NO_ADD=1 GETTEXT_BIN_DIR=/result/bin GETTEXT_LIB_DIR=/result/lib GETTEXT_INCLUDE_DIR=/result/include
     - os: osx
+      osx_image: xcode12.2
       rust: stable
       env: TARGET=x86_64-apple-darwin NO_ADD=1 HOMEBREW=1 GETTEXT_DIR=/usr/local/opt/gettext
     - os: osx
+      osx_image: xcode12.2
       rust: stable
       env: TARGET=x86_64-apple-darwin NO_ADD=1
     - os: linux


### PR DESCRIPTION
This should fix Homebrew warnings about old Xcode.