### PR TITLE
WIP: macros: only format strings after passing them to gettext

### DIFF
--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -15,7 +15,7 @@
 //! println!("Translated: {}", gettext("Hello, world!"));
 //! println!("Singular: {}", ngettext("One thing", "Multiple things", 1));
 //! println!("Plural: {}", ngettext("One thing", "Multiple things", 2));
-//! println!("With placeholder: {}", gettext!("Hello, {user}!", user = "Example User"));
+//! println!("With placeholder: {}", gettext!("Hello, {}!",  "Example User"));
 //! ```
 //!
 //! Alternatively, you can initialize the locale and text domain using the [`TextDomain`] builder.
@@ -87,7 +87,7 @@ use std::ffi::CString;
 use std::os::raw::c_ulong;
 use std::path::PathBuf;
 
-mod macros;
+pub mod macros;
 pub use macros::*;
 mod text_domain;
 pub use text_domain::{TextDomain, TextDomainError};


### PR DESCRIPTION
Previously we would format the strings and then pass them to gettext. This would
lead to gettext not being able to find the strings in the .po file (since that
contains the unformatted strings).

fixes #18

First shot at this @Minoru , I'll have to test this more at the weekend with actual .po files and stuff