### PR TITLE
Make *textdomain* functions fallible

### DIFF
--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -22,7 +22,7 @@ use gettextrs::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     textdomain("hellorust")?;
-    bindtextdomain("hellorust", "/usr/local/share/locale");
+    bindtextdomain("hellorust", "/usr/local/share/locale")?;
 
     // It's sufficient to call any one of those two. See "UTF-8 is required" in the
     // rustdocs.

--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -20,19 +20,23 @@ want or can't do that, there are two ways out:
 ```rust
 use gettextrs::*;
 
-textdomain("hellorust");
-bindtextdomain("hellorust", "/usr/local/share/locale");
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    textdomain("hellorust")?;
+    bindtextdomain("hellorust", "/usr/local/share/locale");
 
-// It's sufficient to call any one of those two. See "UTF-8 is required" in the
-// rustdocs.
-setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-bind_textdomain_codeset("hellorust", "UTF-8");
+    // It's sufficient to call any one of those two. See "UTF-8 is required" in the
+    // rustdocs.
+    setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+    bind_textdomain_codeset("hellorust", "UTF-8");
 
-println!("Translated: {}", gettext("Hello, world!"));
-println!("Singular: {}", ngettext("One thing", "Multiple things", 1));
-println!("Plural: {}", ngettext("One thing", "Multiple things", 2));
-println!("With context: {}", pgettext("This is the context", "Hello, world!"));
-println!("Plural with context: {}", npgettext("This is the context", "One thing", "Multiple things", 2));
+    println!("Translated: {}", gettext("Hello, world!"));
+    println!("Singular: {}", ngettext("One thing", "Multiple things", 1));
+    println!("Plural: {}", ngettext("One thing", "Multiple things", 2));
+    println!("With context: {}", pgettext("This is the context", "Hello, world!"));
+    println!("Plural with context: {}", npgettext("This is the context", "One thing", "Multiple things", 2));
+
+    Ok(())
+}
 ```
 
 Alternatively, you can initialize the locale and text domain using the `TextDomain` builder.

--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // It's sufficient to call any one of those two. See "UTF-8 is required" in the
     // rustdocs.
     setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-    bind_textdomain_codeset("hellorust", "UTF-8");
+    bind_textdomain_codeset("hellorust", "UTF-8")?;
 
     println!("Translated: {}", gettext("Hello, world!"));
     println!("Singular: {}", ngettext("One thing", "Multiple things", 1));

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -342,18 +342,22 @@ where
 
 /// Set current locale for translations.
 ///
+/// Returns an opaque string that describes the locale set. You can pass that string into
+/// `setlocale()` later to set the same local again. `None` means the call failed (the underlying
+/// API doesn't provide any details).
+///
 /// # Panics
 ///
 /// Panics if `locale` contains an internal 0 byte, as such values can't be passed to the gettext's
 /// C API.
-pub fn setlocale<T: Into<Vec<u8>>>(category: LocaleCategory, locale: T) -> Option<String> {
+pub fn setlocale<T: Into<Vec<u8>>>(category: LocaleCategory, locale: T) -> Option<Vec<u8>> {
     let c = CString::new(locale).expect("`locale` contains an internal 0 byte");
     unsafe {
         let ret = ffi::setlocale(category as i32, c.as_ptr());
         if ret.is_null() {
             None
         } else {
-            Some(CStr::from_ptr(ret).to_string_lossy().into_owned())
+            Some(CStr::from_ptr(ret).to_bytes().to_owned())
         }
     }
 }

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -306,10 +306,12 @@ where
         use std::ffi::OsString;
         use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
-        let dir: Vec<u16> = dir.encode_wide().collect();
+        let mut dir: Vec<u16> = dir.encode_wide().collect();
         if dir.contains(&0) {
             panic!("`dir` contains an internal 0 byte");
         }
+        // Trailing zero to mark the end of the C string.
+        dir.push(0);
         unsafe {
             let result = {
                 let mut ptr = ffi::wbindtextdomain(domain.as_ptr(), dir.as_ptr());

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -103,7 +103,7 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
         bindtextdomain("hellorust", "/usr/local/share/locale");
-        textdomain("hellorust");
+        textdomain("hellorust").unwrap();
 
         assert_eq!(gettext!("Hello, {}!", "world"), "Hello, world!");
         assert_eq!(
@@ -117,7 +117,7 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
         bindtextdomain("hellorust", "/usr/local/share/locale");
-        textdomain("hellorust");
+        textdomain("hellorust").unwrap();
 
         assert_eq!(
             ngettext!("Singular {}!", "Multiple {}!", 2, "Worlds"),
@@ -130,7 +130,7 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
         bindtextdomain("hellorust", "/usr/local/share/locale");
-        textdomain("hellorust");
+        textdomain("hellorust").unwrap();
 
         assert_eq!("Hello, world!", pgettext!("context", "Hello, {}!", "world"));
     }
@@ -140,7 +140,7 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
         bindtextdomain("hellorust", "/usr/local/share/locale");
-        textdomain("hellorust");
+        textdomain("hellorust").unwrap();
 
         assert_eq!(
             "Multiple Worlds!",

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -102,7 +102,7 @@ mod test {
     fn test_gettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(gettext!("Hello, {}!", "world"), "Hello, world!");
@@ -116,7 +116,7 @@ mod test {
     fn test_ngettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
@@ -129,7 +129,7 @@ mod test {
     fn test_pgettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!("Hello, world!", pgettext!("context", "Hello, {}!", "world"));
@@ -139,7 +139,7 @@ mod test {
     fn test_npgettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
@@ -152,7 +152,7 @@ mod test {
     fn test_dgettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
             "Hello, world!",
@@ -164,7 +164,7 @@ mod test {
     fn test_dcgettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
             "Hello, world!",
@@ -176,7 +176,7 @@ mod test {
     fn test_dcngettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
             "Singular World",
@@ -195,7 +195,7 @@ mod test {
     fn test_dngettext_macro() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
 
-        bindtextdomain("hellorust", "/usr/local/share/locale");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
             "Singular World!",

--- a/gettext-rs/src/text_domain.rs
+++ b/gettext-rs/src/text_domain.rs
@@ -243,7 +243,8 @@ impl TextDomain {
     }
 
     /// Search for translations in the search paths and initialize the `locale` and `textdomain`.
-    /// Return an `Option` with the locale (i.e. the result from the call to [`setlocale`]) if:
+    /// Return an `Option` with the opaque string that describes the locale set (i.e. the result
+    /// from the call to [`setlocale`]) if:
     ///
     /// - a translation of the text domain in the requested language was found,
     /// - the locale is valid.
@@ -260,11 +261,11 @@ impl TextDomain {
     ///
     /// [`TextDomainError`]: enum.TextDomainError.html
     /// [`setlocale`]: fn.setlocale.html
-    pub fn init(mut self) -> Result<Option<String>, TextDomainError> {
+    pub fn init(mut self) -> Result<Option<Vec<u8>>, TextDomainError> {
         let (req_locale, norm_locale) = match self.locale.take() {
             Some(req_locale) => {
                 if req_locale == "C" || req_locale == "POSIX" {
-                    return Ok(Some(req_locale));
+                    return Ok(Some(req_locale.as_bytes().to_owned()));
                 }
                 match LanguageRange::new(&req_locale) {
                     Ok(lang_range) => (req_locale.clone(), lang_range.into()),

--- a/gettext-rs/src/text_domain.rs
+++ b/gettext-rs/src/text_domain.rs
@@ -17,6 +17,8 @@ pub enum TextDomainError {
     TextDomainCallFailed(std::io::Error),
     /// The call to `bindtextdomain()` failed.
     BindTextDomainCallFailed(std::io::Error),
+    /// The call to `bind_textdomain_codeset()` failed.
+    BindTextDomainCodesetCallFailed(std::io::Error),
 }
 
 /// A text domain initializer builder which finds the path to bind by searching translations
@@ -100,6 +102,9 @@ pub enum TextDomainError {
 ///         e.to_string()
 ///     }
 ///     Err(TextDomainError::BindTextDomainCallFailed(e)) => {
+///         e.to_string()
+///     }
+///     Err(TextDomainError::BindTextDomainCodesetCallFailed(e)) => {
 ///         e.to_string()
 ///     }
 /// };
@@ -352,7 +357,8 @@ impl TextDomain {
                     let result = setlocale(locale_category, req_locale);
                     bindtextdomain(name.clone(), path.join("locale"))
                         .map_err(TextDomainError::BindTextDomainCallFailed)?;
-                    bind_textdomain_codeset(name.clone(), codeset);
+                    bind_textdomain_codeset(name.clone(), codeset)
+                        .map_err(TextDomainError::BindTextDomainCodesetCallFailed)?;
                     textdomain(name).map_err(TextDomainError::TextDomainCallFailed)?;
                     Ok(result)
                 },

--- a/gettext-rs/src/text_domain.rs
+++ b/gettext-rs/src/text_domain.rs
@@ -350,10 +350,8 @@ impl TextDomain {
                 Err(TextDomainError::TranslationNotFound(lang)),
                 |path| {
                     let result = setlocale(locale_category, req_locale);
-                    bindtextdomain(
-                        name.clone(),
-                        path.join("locale").to_str().unwrap().to_owned(),
-                    ).map_err(TextDomainError::BindTextDomainCallFailed)?;
+                    bindtextdomain(name.clone(), path.join("locale"))
+                        .map_err(TextDomainError::BindTextDomainCallFailed)?;
                     bind_textdomain_codeset(name.clone(), codeset);
                     textdomain(name).map_err(TextDomainError::TextDomainCallFailed)?;
                     Ok(result)

--- a/gettext-rs/src/text_domain.rs
+++ b/gettext-rs/src/text_domain.rs
@@ -15,6 +15,8 @@ pub enum TextDomainError {
     TranslationNotFound(String),
     /// The call to `textdomain()` failed.
     TextDomainCallFailed(std::io::Error),
+    /// The call to `bindtextdomain()` failed.
+    BindTextDomainCallFailed(std::io::Error),
 }
 
 /// A text domain initializer builder which finds the path to bind by searching translations
@@ -95,6 +97,9 @@ pub enum TextDomainError {
 ///         format!("invalid locale {}", locale)
 ///     }
 ///     Err(TextDomainError::TextDomainCallFailed(e)) => {
+///         e.to_string()
+///     }
+///     Err(TextDomainError::BindTextDomainCallFailed(e)) => {
 ///         e.to_string()
 ///     }
 /// };
@@ -348,7 +353,7 @@ impl TextDomain {
                     bindtextdomain(
                         name.clone(),
                         path.join("locale").to_str().unwrap().to_owned(),
-                    );
+                    ).map_err(TextDomainError::BindTextDomainCallFailed)?;
                     bind_textdomain_codeset(name.clone(), codeset);
                     textdomain(name).map_err(TextDomainError::TextDomainCallFailed)?;
                     Ok(result)


### PR DESCRIPTION
This PR is kind of in the middle between #35 and #44: textdomain-related functions returned `String`, which wasn't always appropriate, and they also hid the errors in the underlying API. This PR fixes all that.

Most of these changes are breaking.