### PR TITLE
Fix wbindtextdomain call

### DIFF
--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -292,6 +292,7 @@ where
 
     #[cfg(windows)]
     {
+        use std::ffi::OsString;
         use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
         let dir: Vec<u16> = dir.encode_wide().collect();
@@ -299,7 +300,16 @@ where
             panic!("`dir` contains an internal 0 byte");
         }
         unsafe {
-            OsString::from_wide(&ffi::wbindtextdomain(domain.as_ptr(), &dir.as_ptr()))
+            let result = {
+                let mut ptr = ffi::wbindtextdomain(domain.as_ptr(), dir.as_ptr());
+                let mut result = vec![];
+                while *ptr != 0_u16 {
+                    result.push(*ptr);
+                    ptr = ptr.offset(1);
+                }
+                result
+            };
+            OsString::from_wide(&result)
                 .to_string_lossy()
                 .into_owned()
         }

--- a/gettext-sys/lib.rs
+++ b/gettext-sys/lib.rs
@@ -1,6 +1,8 @@
 use std::os::raw::{c_char, c_int, c_ulong};
+
 #[cfg(windows)]
-use std::os::raw::wchar_t;
+#[allow(non_camel_case_types)]
+type wchar_t = u16;
 
 extern "C" {
     pub fn gettext(s: *const c_char) -> *mut c_char;


### PR DESCRIPTION
While working on https://github.com/Koka/gettext-rs/issues/12#issuecomment-787205155 I managed to get the crates into a buildable state, and so fixed my erroneous conversions around the `wbindtextdomain` call.

I still have no idea if it actually *works*, because I couldn't link anything and thus couldn't run tests. Come to think of it, our tests don't actually test the behaviour of these calls anyway, so *shrug*. At least the next person who touches this code won't have to start from scratch.