### PR TITLE
gettext-sys: build in a temporary directory

### DIFF
--- a/gettext-sys/CHANGELOG.md
+++ b/gettext-sys/CHANGELOG.md
@@ -7,9 +7,13 @@
 - Checks for build tools required by GNU gettext (Dean Leggo)
 - Bindings for `wbindtextdomain` (only available on Windows) (Alexander
     Batischev)
+- Build-time dependency on `tempfile` (Alexander Batischev)
 
 ### Changed
 - Bump bundled GNU gettext to 0.21 (Alexander Batischev)
+
+### Fixed
+- Build failure when a path contains spaces (Alexander Batischev)
 
 
 

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -16,3 +16,4 @@ gettext-system = []
 
 [build-dependencies]
 cc = "1.0"
+tempfile = "3"

--- a/gettext-sys/README.md
+++ b/gettext-sys/README.md
@@ -56,6 +56,17 @@ ways out:
 
 - `NUM_JOBS`: sets the number of parallel build jobs.
 
+- `TMPDIR` (on Unix), `TMP`, `TEMP`, `USERPROFILE` (on Windows): set the
+    parent directory for the temporary build directory.
+
+    GNU gettext uses autotools, which [don't allow some characters][chars] in
+    paths, notably a space character. To get around that, this crate performs
+    the build in a temporary directory which usually resides somewhere under
+    _/tmp_ or _C:\\Temp_. The aforementioned env vars allow you to move the
+    build directory elsewhere.
+
+    [chars]: https://www.gnu.org/software/autoconf/manual/autoconf-2.60/autoconf.html#Special-Chars-in-Variables
+
 For target-specific configuration, each of these environment variables can be
 prefixed by an upper-cased target, for example,
 `X86_64_UNKNOWN_LINUX_GNU_GETTEXT_DIR`. This can be useful in cross compilation


### PR DESCRIPTION
This works around the autotools limitation, which prevented us from
building in directories whose absolute paths have spaces in them.

Fixes #9.