### PR TITLE
impl Error for TextDomainError

### DIFF
--- a/gettext-rs/CHANGELOG.md
+++ b/gettext-rs/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Functions to query gettext configuration. These are wrappers over
     `textdomain(NULL)`, `bindtextdomain(domain, NULL)`, and
     `bind_textdomain_codeset(domain, NULL)` (Alexander Batischev)
+- `impl Error` for `TextDomainError`, which makes it easier to use with `?`
+    operator (Alexander Batischev)
 
 ### Changed
 - **Users are required to configure gettext for UTF-8, either explicitly with

--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // You could also use `TextDomain` builder which calls `textdomain` and
     // other functions for you:
     //
-    // TextDomain::new("hellorust").init().unwrap();
+    // TextDomain::new("hellorust").init()?;
 
     // `gettext()` simultaneously marks a string for translation and translates
     // it at runtime.

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -87,8 +87,7 @@ use std::io;
 use std::os::raw::c_ulong;
 use std::path::PathBuf;
 
-pub mod macros;
-pub use macros::*;
+mod macros;
 mod text_domain;
 pub use text_domain::{TextDomain, TextDomainError};
 pub mod getters;

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -14,7 +14,7 @@
 //!     // You could also use `TextDomain` builder which calls `textdomain` and
 //!     // other functions for you:
 //!     //
-//!     // TextDomain::new("hellorust").init().unwrap();
+//!     // TextDomain::new("hellorust").init()?;
 //!
 //!     // `gettext()` simultaneously marks a string for translation and translates
 //!     // it at runtime.
@@ -57,10 +57,12 @@
 //!
 //! ```rust,no_run
 //! # use gettextrs::*;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! TextDomain::new("hellorust")
 //!     .codeset("UTF-8") // Optional, the builder does this by default
-//!     .init()
-//!     .unwrap();
+//!     .init()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! This crate doesn't do this for you because the encoding is a global setting; changing it can

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -1,19 +1,4 @@
 //! Macros that translate the message and then replace placeholders in it.
-//!
-//! You can think of these as `format!(gettext(msgid), value1, value2…)`, but please bear in mind
-//! that the only supported placeholder is `{}`. **You cannot use any of std::fmt goodies with
-//! these macros**. The only way to get around that is to pre-format the argument which you then
-//! insert into a translated string:
-//!
-//! ```rust,no_run
-//! # use gettextrs::*;
-//! let x = 42_u64;
-//! gettext!(
-//!     "In binary, {} is {}, but it's {} in hexadecimal",
-//!     x,
-//!     format!("{:b}", x),
-//!     format!("{:x}", x));
-//! ```
 
 /// This is an implementation detail for counting arguments in the gettext macros. Don't call this directly.
 #[macro_export]


### PR DESCRIPTION
This makes it easier to use `TextDomain` with the `?` operator.

b3b78ed fixes a little mistake that slipped through in #47: we made the `mod macros` public, but it doesn't make sense since that module only contains macros, which are hoisted to the crate root by `#[macro_export]`.