### PR TITLE
Improved macros

### DIFF
--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -113,7 +113,7 @@ macro_rules! dcgettext {
 /// Like [`ngettext`], but allows for formatting.
 ///
 /// It calls [`ngettext`] on `msgid`, `msgid_plural`, and `n`, and then replaces each occurrence of
-/// `{}` with the next value out of `args`.
+/// `{}` with the next value out of `args`, and `{n}` with `n`.
 ///
 /// # Panics
 ///
@@ -123,12 +123,16 @@ macro_rules! dcgettext {
 /// [`ngettext`]: fn.ngettext.html
 #[macro_export]
 macro_rules! ngettext {
-    ( $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
-        $crate::ngettext($msgid, $msgid_plural, $n)
-    };
+    ( $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {{
+        let mut msgstr = $crate::ngettext($msgid, $msgid_plural, $n);
+        while msgstr.contains("{n}") {
+            msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
+        }
+        msgstr
+    }};
     ( $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
         let mut msgstr = $crate::ngettext($msgid, $msgid_plural, $n);
-        if msgstr.contains("{n}") {
+        while msgstr.contains("{n}") {
             msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
         }
         $crate::rt_format!(msgstr, "{}", $($args),+)
@@ -138,7 +142,7 @@ macro_rules! ngettext {
 /// Like [`dngettext`], but allows for formatting.
 ///
 /// It calls [`dngettext`] on `domainname`, `msgid`, `msgid_plural`, and `n`, and then replaces
-/// each occurrence of `{}` with the next value out of `args`.
+/// each occurrence of `{}` with the next value out of `args`, and `{n}` with `n`.
 ///
 /// # Panics
 ///
@@ -148,12 +152,16 @@ macro_rules! ngettext {
 /// [`dngettext`]: fn.dngettext.html
 #[macro_export]
 macro_rules! dngettext {
-    ( $domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
-        $crate::dngettext($domainname, $msgid, $msgid_plural, $n)
-    };
+    ( $domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {{
+        let mut msgstr = $crate::dngettext($domainname, $msgid, $msgid_plural, $n);
+        while msgstr.contains("{n}") {
+            msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
+        }
+        msgstr
+    }};
     ( $domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
         let mut msgstr = $crate::dngettext($domainname, $msgid, $msgid_plural, $n);
-        if msgstr.contains("{n}") {
+        while msgstr.contains("{n}") {
             msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
         }
         $crate::rt_format!(msgstr, "{}", $($args),+)
@@ -163,7 +171,7 @@ macro_rules! dngettext {
 /// Like [`dcngettext`], but allows for formatting.
 ///
 /// It calls [`dcngettext`] on `domainname`, `category`, `msgid`, `msgid_plural`, and `n`, and then
-/// replaces each occurrence of `{}` with the next value out of `args`.
+/// replaces each occurrence of `{}` with the next value out of `args`, and `{n}` with `n`.
 ///
 /// # Panics
 ///
@@ -173,12 +181,17 @@ macro_rules! dngettext {
 /// [`dcngettext`]: fn.dcngettext.html
 #[macro_export]
 macro_rules! dcngettext {
-    ( $domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
-        $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category)
-    };
-    ( $domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+    ( $domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {{
         let mut msgstr = $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category);
-        if msgstr.contains("{n}") {
+        while msgstr.contains("{n}") {
+            msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
+        }
+        msgstr
+    }};
+    ( $domainname:expr, $category:expr,
+      $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category);
+        while msgstr.contains("{n}") {
             msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
         }
         $crate::rt_format!(msgstr, "{}", $($args),+)
@@ -213,7 +226,7 @@ macro_rules! pgettext {
 /// Like [`npgettext`], but allows for formatting.
 ///
 /// It calls [`npgettext`] on `msgctxt`, `msgid`, `msgid_plural`, and `n`, and then replaces each
-/// occurrence of `{}` with the next value out of `args`.
+/// occurrence of `{}` with the next value out of `args`, and `{n}` with `n`.
 ///
 /// # Panics
 ///
@@ -223,12 +236,16 @@ macro_rules! pgettext {
 /// [`npgettext`]: fn.npgettext.html
 #[macro_export]
 macro_rules! npgettext {
-    ( $msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
-        $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n)
-    };
+    ( $msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {{
+        let mut msgstr = $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n);
+        while msgstr.contains("{n}") {
+            msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
+        }
+        msgstr
+    }};
     ( $msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
         let mut msgstr = $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n);
-        if msgstr.contains("{n}") {
+        while msgstr.contains("{n}") {
             msgstr = $crate::macros::rt_format(&msgstr, "{n}", $n);
         }
         $crate::rt_format!(msgstr, "{}", $($args),+)
@@ -704,43 +721,96 @@ mod test {
 
 
     #[test]
-    fn special_n_formatting() {
+    fn ngettext_special_n_formatting() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-        {
-            textdomain("hellorust").unwrap();
-            assert_eq!(
-                ngettext!(
-                    "There is {n} \"{}\" in text!",
-                    "There are {n} \"{}\" in text!",
-                    2, "UwU"
-                ),
-                "There are 2 \"UwU\" in text!"
-            );
-            assert_eq!(
-                npgettext!("context",
-                    "There is {n} \"{}\" in text!",
-                    "There are {n} \"{}\" in text!",
-                    2, "UwU"
-                ),
-                "There are 2 \"UwU\" in text!"
-            );
-        };
+        textdomain("hellorust").unwrap();
+
+        assert_eq!(
+            ngettext!(
+                "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            ngettext!(
+                "There is {n} \"{}\" in text! Only {n}!",
+                "There are {n} \"{}\" in text! Only {n}!",
+                2, "UwU"
+            ),
+            "There are 2 \"UwU\" in text! Only 2!"
+        );
+    }
+
+    #[test]
+    fn dngettext_special_n_formatting() {
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+
         assert_eq!(
             dngettext!("hellorust",
-                    "There is {n} \"{}\" in text!",
-                    "There are {n} \"{}\" in text!",
-                    2, "UwU"
-                ),
-            "There are 2 \"UwU\" in text!"
+                "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is {n} \"{}\" in text! Only {n}!",
+                "There are {n} \"{}\" in text! Only {n}!",
+                2, "UwU"
+            ),
+            "There are 2 \"UwU\" in text! Only 2!"
+        );
+    }
+
+    #[test]
+    fn dcngettext_special_n_formatting() {
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
         );
         assert_eq!(
             dcngettext!("hellorust", LocaleCategory::LcAll,
-                    "There is {n} \"{}\" in text!",
-                    "There are {n} \"{}\" in text!",
-                    2, "UwU"
-                ),
-            "There are 2 \"UwU\" in text!"
+                "There is {n} \"{}\" in text! Only {n}!",
+                "There are {n} \"{}\" in text! Only {n}!",
+                2, "UwU"
+            ),
+            "There are 2 \"UwU\" in text! Only 2!"
+        );
+    }
+
+    #[test]
+    fn npgettext_special_n_formatting() {
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+        textdomain("hellorust").unwrap();
+
+        assert_eq!(
+            npgettext!("context",
+                "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            npgettext!("context",
+                "There is {n} \"{}\" in text! Only {n}!",
+                "There are {n} \"{}\" in text! Only {n}!",
+                2, "UwU"
+            ),
+            "There are 2 \"UwU\" in text! Only 2!"
         );
     }
 

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -1,27 +1,34 @@
 //! Macros that translate the message and then replace placeholders in it.
 
-/// This is an implementation detail for counting arguments in the gettext macros. Don't call this directly.
-#[macro_export]
+/// This is an implementation detail for replacing arguments in the gettext macros.
+/// Don't call this directly.
 #[doc(hidden)]
-macro_rules! count_args {
-    () => { 0 };
-    ($_e: expr $(, $rest: expr)*) => { 1 + $crate::count_args!($($rest),*) }
+#[allow(dead_code)]
+pub fn rt_format<T: std::fmt::Display>(msgstr: &str, arg: T, pat: &str) -> String {
+    match msgstr.split_once(pat) {
+        Some((pre, suf)) => { format!("{}{}{}", pre, arg, suf) }
+        None => {
+            debug_assert!(false, "There are more arguments than format directives");
+            msgstr.to_string()
+        }
+    }
 }
 
-/// This is an implementation detail for replacing arguments in the gettext macros. Don't call this directly.
+/// This is an implementation detail for replacing arguments in the gettext macros.
+/// Don't call this directly.
 #[macro_export]
 #[doc(hidden)]
-macro_rules! freplace {
-    ($format:expr, $($args:expr),+ $(,)?) => {{
-        let mut parts = $format.split("{}");
-        debug_assert_eq!(parts.clone().count() - 1, $crate::count_args!($($args),*), "Argument count has to match number of format directives ({{}})");
-
-        let mut output = parts.next().unwrap_or_default().to_string();
-        $(
-            output += &format!("{}{}", $args, &parts.next().expect("Argument count has to match number of format directives ({})"));
-        )*
-        output
-    }};
+macro_rules! rt_format {
+	( $msgstr:expr, $pat:expr, ) => {
+		$msgstr
+	};
+	( $msgstr:expr, $pat:expr, $arg:expr $(, $rest: expr)* ) => {{
+		$crate::rt_format!(
+            $crate::macros::rt_format(&$msgstr, $arg, $pat),
+            $pat,
+            $($rest),*
+        )
+	}};
 }
 
 /// Like [`gettext`], but allows for formatting.
@@ -29,12 +36,26 @@ macro_rules! freplace {
 /// It calls [`gettext`] on `msgid`, and then replaces each occurrence of `{}` with the next value
 /// out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`gettext`]: fn.gettext.html
 #[macro_export]
 macro_rules! gettext {
-    ($msgid:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::gettext($msgid);
-        $crate::freplace!(format, $($args),*)
+    ( $msgid:expr $(,)? ) => {
+        $crate::gettext($msgid)
+    };
+    ( $msgid:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::gettext($msgid);
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
     }};
 }
 
@@ -43,12 +64,26 @@ macro_rules! gettext {
 /// It calls [`dgettext`] on `domainname` and `msgid`, and then replaces each occurrence of `{}`
 /// with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`dgettext`]: fn.dgettext.html
 #[macro_export]
 macro_rules! dgettext {
-    ($domainname:expr, $msgid:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::dgettext($domainname, $msgid);
-        $crate::freplace!(format, $($args),*)
+    ( $domainname:expr, $msgid:expr $(,)? ) => {
+        $crate::dgettext($domainname, $msgid)
+    };
+    ( $domainname:expr, $msgid:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::dgettext($domainname, $msgid);
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
     }};
 }
 
@@ -57,12 +92,26 @@ macro_rules! dgettext {
 /// It calls [`dcgettext`] on `domainname`, `category`, and `msgid`, and then replaces each
 /// occurrence of `{}` with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`dcgettext`]: fn.dcgettext.html
 #[macro_export]
 macro_rules! dcgettext {
-    ($domainname:expr, $category:expr, $msgid:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::dcgettext($domainname, $msgid, $category);
-        $crate::freplace!(format, $($args),*)
+    ( $domainname:expr, $category:expr, $msgid:expr $(,)? ) => {
+        $crate::dcgettext($domainname, $msgid, $category)
+    };
+    ( $domainname:expr, $category:expr, $msgid:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::dcgettext($domainname, $msgid, $category);
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
     }};
 }
 
@@ -71,13 +120,30 @@ macro_rules! dcgettext {
 /// It calls [`ngettext`] on `msgid`, `msgid_plural`, and `n`, and then replaces each occurrence of
 /// `{}` with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`ngettext`]: fn.ngettext.html
 #[macro_export]
 macro_rules! ngettext {
-    ($msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::ngettext($msgid, $msgid_plural, $n);
-        $crate::freplace!(format, $($args),*)
-    }}
+    ( $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
+        $crate::ngettext($msgid, $msgid_plural, $n)
+    };
+    ( $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::ngettext($msgid, $msgid_plural, $n);
+        if msgstr.contains("{n}") == true {
+            msgstr = $crate::macros::rt_format(&msgstr, $n, "{n}");
+        }
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
+    }};
 }
 
 /// Like [`dngettext`], but allows for formatting.
@@ -85,13 +151,30 @@ macro_rules! ngettext {
 /// It calls [`dngettext`] on `domainname`, `msgid`, `msgid_plural`, and `n`, and then replaces
 /// each occurrence of `{}` with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`dngettext`]: fn.dngettext.html
 #[macro_export]
 macro_rules! dngettext {
-    ($domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::dngettext($domainname, $msgid, $msgid_plural, $n);
-        $crate::freplace!(format, $($args),*)
-    }}
+    ( $domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
+        $crate::dngettext($domainname, $msgid, $msgid_plural, $n)
+    };
+    ( $domainname:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::dngettext($domainname, $msgid, $msgid_plural, $n);
+        if msgstr.contains("{n}") == true {
+            msgstr = $crate::macros::rt_format(&msgstr, $n, "{n}");
+        }
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
+    }};
 }
 
 /// Like [`dcngettext`], but allows for formatting.
@@ -99,13 +182,30 @@ macro_rules! dngettext {
 /// It calls [`dcngettext`] on `domainname`, `category`, `msgid`, `msgid_plural`, and `n`, and then
 /// replaces each occurrence of `{}` with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`dcngettext`]: fn.dcngettext.html
 #[macro_export]
 macro_rules! dcngettext {
-    ($domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category);
-        $crate::freplace!(format, $($args),*)
-    }}
+    ( $domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
+        $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category)
+    };
+    ( $domainname:expr, $category:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::dcngettext($domainname, $msgid, $msgid_plural, $n, $category);
+        if msgstr.contains("{n}") == true {
+            msgstr = $crate::macros::rt_format(&msgstr, $n, "{n}");
+        }
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
+    }};
 }
 
 /// Like [`pgettext`], but allows for formatting.
@@ -113,13 +213,27 @@ macro_rules! dcngettext {
 /// It calls [`pgettext`] on `msgctxt` and `msgid`, and then replaces each occurrence of `{}` with
 /// the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`pgettext`]: fn.pgettext.html
 #[macro_export]
 macro_rules! pgettext {
-    ($msgctxt:expr, $msgid:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::pgettext($msgctxt, $msgid);
-        $crate::freplace!(format, $($args),*)
-    }}
+    ( $msgctxt:expr, $msgid:expr $(,)? ) => {
+        $crate::pgettext($msgctxt, $msgid)
+    };
+    ( $msgctxt:expr, $msgid:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::pgettext($msgctxt, $msgid);
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
+    }};
 }
 
 /// Like [`npgettext`], but allows for formatting.
@@ -127,121 +241,571 @@ macro_rules! pgettext {
 /// It calls [`npgettext`] on `msgctxt`, `msgid`, `msgid_plural`, and `n`, and then replaces each
 /// occurrence of `{}` with the next value out of `args`.
 ///
+/// # Panics
+///
+/// When building the `dev` profile,
+/// it panics if the number of arguments doesn't match the number of format directives.
+///
 /// [`npgettext`]: fn.npgettext.html
 #[macro_export]
 macro_rules! npgettext {
-    ($msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)?) => {{
-        let format = $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n);
-        $crate::freplace!(format, $($args),*)
-    }}
+    ( $msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr $(,)? ) => {
+        $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n)
+    };
+    ( $msgctxt:expr, $msgid:expr, $msgid_plural:expr, $n:expr, $($args:expr),+ $(,)? ) => {{
+        let mut msgstr = $crate::npgettext($msgctxt, $msgid, $msgid_plural, $n);
+        if msgstr.contains("{n}") == true {
+            msgstr = $crate::macros::rt_format(&msgstr, $n, "{n}");
+        }
+        msgstr = $crate::rt_format!(msgstr, "{}", $($args),+);
+        debug_assert!(
+            !msgstr.contains("{}"),
+            "There are less arguments than format directives"
+        );
+
+        msgstr
+    }};
 }
 
 #[cfg(test)]
 mod test {
     use crate::*;
+    use std::panic::catch_unwind;
 
     #[test]
-    fn test_gettext_macro() {
+    fn no_formatting() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-        textdomain("hellorust").unwrap();
+        {
+            textdomain("hellorust").unwrap();
 
-        assert_eq!(gettext!("Hello, {}!", "world"), "Hello, world!");
+            assert_eq!(
+                gettext!("Hello, World!"),
+                "Hello, World!"
+            );
+            assert_eq!(
+                ngettext!(
+                    "There is one result",
+                    "There are few results",
+                    2
+                ),
+                "There are few results"
+            );
+            assert_eq!(
+                pgettext!("context",
+                    "Hello, World!"
+                ),
+                "Hello, World!"
+            );
+            assert_eq!(
+                npgettext!("context",
+                    "There is one result",
+                    "There are few results",
+                    2
+                ),
+                "There are few results"
+            );
+        };
         assert_eq!(
-            gettext!("Hello, {} {}!", "small", "world"),
-            "Hello, small world!"
+            dgettext!("hellorust",
+                "Hello, World!"
+            ),
+            "Hello, World!"
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is one result",
+                "There are few results",
+                2
+            ),
+            "There are few results"
+        );
+        assert_eq!(
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, World!"
+            ),
+            "Hello, World!"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one result",
+                "There are few results",
+                2
+            ),
+            "There are few results"
         );
     }
 
     #[test]
-    fn test_ngettext_macro() {
+    fn basic_formatting() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-        textdomain("hellorust").unwrap();
+        {
+            textdomain("hellorust").unwrap();
 
+            assert_eq!(
+                gettext!("Hello, {}! {}", "World", "UwU"),
+                "Hello, World! UwU"
+            );
+            assert_eq!(
+                ngettext!(
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU", "OwO"
+                ),
+                "There are few \"UwU\" in text! OwO"
+            );
+            assert_eq!(
+                pgettext!("context",
+                    "Hello, {}! {}", "World", "UwU"
+                ),
+                "Hello, World! UwU"
+            );
+            assert_eq!(
+                npgettext!("context",
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU", "OwO"
+                ),
+                "There are few \"UwU\" in text! OwO"
+            );
+        };
         assert_eq!(
-            ngettext!("Singular {}!", "Multiple {}!", 2, "Worlds"),
-            "Multiple Worlds!"
+            dgettext!("hellorust",
+                "Hello, {}! {}", "World", "UwU"
+            ),
+            "Hello, World! UwU"
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU", "OwO"
+            ),
+            "There are few \"UwU\" in text! OwO"
+        );
+        assert_eq!(
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, {}! {}", "World", "UwU"
+            ),
+            "Hello, World! UwU"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU", "OwO"
+            ),
+            "There are few \"UwU\" in text! OwO"
         );
     }
 
     #[test]
-    fn test_pgettext_macro() {
+    fn less_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-        textdomain("hellorust").unwrap();
+        {
+            textdomain("hellorust").unwrap();
 
-        assert_eq!("Hello, world!", pgettext!("context", "Hello, {}!", "world"));
-    }
+            match catch_unwind(|| {
+                gettext!("Hello, {}! {}", "World")
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "Hello, World! {}") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are less arguments than format directives"
+                    );
+                }
+            }
 
-    #[test]
-    fn test_npgettext_macro() {
-        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+            match catch_unwind(|| {
+                ngettext!(
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text! {}") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are less arguments than format directives"
+                    );
+                }
+            }
 
-        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-        textdomain("hellorust").unwrap();
+            match catch_unwind(|| {
+                pgettext!("context",
+                    "Hello, {}! {}", "World"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "Hello, World! {}") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are less arguments than format directives"
+                    );
+                }
+            }
 
-        assert_eq!(
-            "Multiple Worlds!",
-            npgettext!("context", "Singular {}!", "Multiple {}!", 2, "Worlds")
-        );
-    }
+            match catch_unwind(|| {
+                npgettext!("context",
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text! {}") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are less arguments than format directives"
+                    );
+                }
+            }
+        };
 
-    #[test]
-    fn test_dgettext_macro() {
-        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
-        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-
-        assert_eq!(
-            "Hello, world!",
-            dgettext!("hellorust", "Hello, {}!", "world")
-        );
-    }
-
-    #[test]
-    fn test_dcgettext_macro() {
-        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
-        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-
-        assert_eq!(
-            "Hello, world!",
-            dcgettext!("hellorust", LocaleCategory::LcAll, "Hello, {}!", "world")
-        );
-    }
-
-    #[test]
-    fn test_dcngettext_macro() {
-        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
-        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
-
-        assert_eq!(
-            "Singular World",
-            dcngettext!(
-                "hellorust",
-                LocaleCategory::LcAll,
-                "Singular {}",
-                "Multiple {}",
-                1,
-                "World"
+        match catch_unwind(|| {
+            dgettext!("hellorust",
+                "Hello, {}! {}", "World"
             )
-        )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "Hello, World! {}") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are less arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dngettext!("hellorust",
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text! {}") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are less arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, {}! {}", "World"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "Hello, World! {}") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are less arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text! {}") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are less arguments than format directives"
+                );
+            }
+        }
     }
 
     #[test]
-    fn test_dngettext_macro() {
+    fn more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
-
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+        {
+            textdomain("hellorust").unwrap();
+
+            match catch_unwind(|| {
+                gettext!("Hello, {}!", "World", "UwU")
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "Hello, World!") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are more arguments than format directives"
+                    );
+                }
+            }
+
+            match catch_unwind(|| {
+                ngettext!(
+                    "There is one \"{}\" in text!",
+                    "There are few \"{}\" in text!",
+                    2, "UwU", "OwO"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text!") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are more arguments than format directives"
+                    );
+                }
+            }
+
+            match catch_unwind(|| {
+                pgettext!("context",
+                    "Hello, {}!", "World", "UwU"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "Hello, World!") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are more arguments than format directives"
+                    );
+                }
+            }
+
+            match catch_unwind(|| {
+                npgettext!("context",
+                    "There is one \"{}\" in text!",
+                    "There are few \"{}\" in text!",
+                    2, "UwU", "OwO"
+                )
+            }) {
+                Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text!") }
+                Err(cause) => {
+                    assert_eq!(
+                        cause.downcast_ref::<&str>().unwrap(),
+                        &"There are more arguments than format directives"
+                    );
+                }
+            }
+        };
+
+        match catch_unwind(|| {
+            dgettext!("hellorust",
+                "Hello, {}!", "World", "UwU"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "Hello, World!") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are more arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dngettext!("hellorust",
+                "There is one \"{}\" in text!",
+                "There are few \"{}\" in text!",
+                2, "UwU", "OwO"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text!") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are more arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, {}!", "World", "UwU"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "Hello, World!") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are more arguments than format directives"
+                );
+            }
+        }
+
+        match catch_unwind(|| {
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one \"{}\" in text!",
+                "There are few \"{}\" in text!",
+                2, "UwU", "OwO"
+            )
+        }) {
+            Ok(msgstr) => { assert_eq!(msgstr, "There are few \"UwU\" in text!") }
+            Err(cause) => {
+                assert_eq!(
+                    cause.downcast_ref::<&str>().unwrap(),
+                    &"There are more arguments than format directives"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn special_n_formatting() {
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+        {
+            textdomain("hellorust").unwrap();
+            assert_eq!(
+                ngettext!(
+                    "There is {n} \"{}\" in text!",
+                    "There are {n} \"{}\" in text!",
+                    2, "UwU"
+                ),
+                "There are 2 \"UwU\" in text!"
+            );
+            assert_eq!(
+                npgettext!("context",
+                    "There is {n} \"{}\" in text!",
+                    "There are {n} \"{}\" in text!",
+                    2, "UwU"
+                ),
+                "There are 2 \"UwU\" in text!"
+            );
+        };
+        assert_eq!(
+            dngettext!("hellorust",
+                    "There is {n} \"{}\" in text!",
+                    "There are {n} \"{}\" in text!",
+                    2, "UwU"
+                ),
+            "There are 2 \"UwU\" in text!"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                    "There is {n} \"{}\" in text!",
+                    "There are {n} \"{}\" in text!",
+                    2, "UwU"
+                ),
+            "There are 2 \"UwU\" in text!"
+        );
+    }
+
+    #[test]
+    fn trailing_comma() {
+        setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
+        bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
+        {
+            textdomain("hellorust").unwrap();
+
+            assert_eq!(
+                gettext!("Hello, World!",),
+                "Hello, World!"
+            );
+            assert_eq!(
+                ngettext!(
+                    "There is one result",
+                    "There are few results",
+                    2,
+                ),
+                "There are few results"
+            );
+            assert_eq!(
+                pgettext!("context",
+                    "Hello, World!",
+                ),
+                "Hello, World!"
+            );
+            assert_eq!(
+                npgettext!("context",
+                    "There is one result",
+                    "There are few results",
+                    2,
+                ),
+                "There are few results"
+            );
+
+            assert_eq!(
+                gettext!("Hello, {}! {}", "World", "UwU",),
+                "Hello, World! UwU"
+            );
+            assert_eq!(
+                ngettext!(
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU", "OwO",
+                ),
+                "There are few \"UwU\" in text! OwO"
+            );
+            assert_eq!(
+                pgettext!("context",
+                    "Hello, {}! {}", "World", "UwU",
+                ),
+                "Hello, World! UwU"
+            );
+            assert_eq!(
+                npgettext!("context",
+                    "There is one \"{}\" in text! {}",
+                    "There are few \"{}\" in text! {}",
+                    2, "UwU", "OwO",
+                ),
+                "There are few \"UwU\" in text! OwO"
+            );
+        };
+        assert_eq!(
+            dgettext!("hellorust",
+                "Hello, World!",
+            ),
+            "Hello, World!",
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is one result",
+                "There are few results",
+                2,
+            ),
+            "There are few results"
+        );
+        assert_eq!(
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, World!",
+            ),
+            "Hello, World!"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one result",
+                "There are few results",
+                2,
+            ),
+            "There are few results"
+        );
 
         assert_eq!(
-            "Singular World!",
-            dngettext!("hellrust", "Singular {}!", "Multiple {}!", 1, "World")
-        )
+            dngettext!("hellorust",
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU", "OwO",
+            ),
+            "There are few \"UwU\" in text! OwO"
+        );
+        assert_eq!(
+            dcgettext!("hellorust", LocaleCategory::LcAll,
+                "Hello, {}! {}", "World", "UwU",
+            ),
+            "Hello, World! UwU"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one \"{}\" in text! {}",
+                "There are few \"{}\" in text! {}",
+                2, "UwU", "OwO",
+            ),
+            "There are few \"UwU\" in text! OwO"
+        );
     }
 }

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -736,6 +736,22 @@ mod test {
         );
         assert_eq!(
             ngettext!(
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                1
+            ),
+            "There is one apple! Only one!"
+        );
+        assert_eq!(
+            ngettext!(
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            ngettext!(
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
                 2, "UwU"
@@ -752,6 +768,22 @@ mod test {
         assert_eq!(
             dngettext!("hellorust",
                 "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                1
+            ),
+            "There is one apple! Only one!"
+        );
+        assert_eq!(
+            dngettext!("hellorust",
+                "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 2
             ),
@@ -782,6 +814,22 @@ mod test {
         );
         assert_eq!(
             dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                1
+            ),
+            "There is one apple! Only one!"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            dcngettext!("hellorust", LocaleCategory::LcAll,
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
                 2, "UwU"
@@ -799,6 +847,22 @@ mod test {
         assert_eq!(
             npgettext!("context",
                 "There is {n} apple! Only {n}!",
+                "There are {n} apples! Only {n}!",
+                2
+            ),
+            "There are 2 apples! Only 2!"
+        );
+        assert_eq!(
+            npgettext!("context",
+                "There is one apple! Only one!",
+                "There are {n} apples! Only {n}!",
+                1
+            ),
+            "There is one apple! Only one!"
+        );
+        assert_eq!(
+            npgettext!("context",
+                "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 2
             ),

--- a/gettext-rs/src/macros.rs
+++ b/gettext-rs/src/macros.rs
@@ -6,7 +6,7 @@
 #[allow(dead_code)]
 pub fn rt_format<T: std::fmt::Display>(msgstr: &str, pat: &str, arg: T) -> String {
     match msgstr.split_once(pat) {
-        Some((pre, suf)) => { format!("{}{}{}", pre, arg, suf) }
+        Some((pre, suf)) => format!("{}{}{}", pre, arg, suf),
         None => {
             debug_assert!(false, "There are more arguments than format directives");
             msgstr.to_string()
@@ -262,10 +262,7 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
-        assert_eq!(
-            gettext!("Hello, World!"),
-            "Hello, World!"
-        );
+        assert_eq!(gettext!("Hello, World!"), "Hello, World!");
     }
 
     #[test]
@@ -273,11 +270,7 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
-        assert_eq!(
-            dgettext!("hellorust",
-                "Hello, World!"),
-            "Hello, World!"
-        );
+        assert_eq!(dgettext!("hellorust", "Hello, World!"), "Hello, World!");
     }
 
     #[test]
@@ -286,8 +279,7 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, World!"),
+            dcgettext!("hellorust", LocaleCategory::LcAll, "Hello, World!"),
             "Hello, World!"
         );
     }
@@ -299,11 +291,7 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            ngettext!(
-                "There is one result",
-                "There are few results",
-                2
-            ),
+            ngettext!("There is one result", "There are few results", 2),
             "There are few results"
         );
     }
@@ -314,7 +302,8 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one result",
                 "There are few results",
                 2
@@ -329,7 +318,9 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one result",
                 "There are few results",
                 2
@@ -344,11 +335,7 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
-        assert_eq!(
-            pgettext!("context",
-                "Hello, World!"),
-            "Hello, World!"
-        );
+        assert_eq!(pgettext!("context", "Hello, World!"), "Hello, World!");
     }
 
     #[test]
@@ -358,15 +345,10 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
-                "There is one result",
-                "There are few results",
-                2
-            ),
+            npgettext!("context", "There is one result", "There are few results", 2),
             "There are few results"
         );
     }
-
 
     #[test]
     fn gettext_basic_formatting() {
@@ -386,8 +368,7 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dgettext!("hellorust",
-                "Hello, {}! {}", "World", "UwU"),
+            dgettext!("hellorust", "Hello, {}! {}", "World", "UwU"),
             "Hello, World! UwU"
         );
     }
@@ -398,8 +379,13 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, {}! {}", "World", "UwU"),
+            dcgettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
+                "Hello, {}! {}",
+                "World",
+                "UwU"
+            ),
             "Hello, World! UwU"
         );
     }
@@ -414,7 +400,9 @@ mod test {
             ngettext!(
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -426,10 +414,13 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -441,10 +432,14 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -457,8 +452,7 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            pgettext!("context",
-                "Hello, {}! {}", "World", "UwU"),
+            pgettext!("context", "Hello, {}! {}", "World", "UwU"),
             "Hello, World! UwU"
         );
     }
@@ -470,57 +464,66 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text! OwO"
         );
     }
 
-
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn gettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
-        assert_eq!(
-            gettext!("Hello, {}! {}", "World"),
-            "Hello, World! {}"
-        );
+        assert_eq!(gettext!("Hello, {}! {}", "World"), "Hello, World! {}");
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn dgettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dgettext!("hellorust",
-                "Hello, {}! {}", "World"),
+            dgettext!("hellorust", "Hello, {}! {}", "World"),
             "Hello, World! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn dcgettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, {}! {}", "World"),
+            dcgettext!("hellorust", LocaleCategory::LcAll, "Hello, {}! {}", "World"),
             "Hello, World! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn ngettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
@@ -530,117 +533,148 @@ mod test {
             ngettext!(
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are few \"UwU\" in text! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn dngettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are few \"UwU\" in text! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn dcngettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are few \"UwU\" in text! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn pgettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            pgettext!("context",
-                "Hello, {}! {}", "World"),
+            pgettext!("context", "Hello, {}! {}", "World"),
             "Hello, World! {}"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are fewer arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are fewer arguments than format directives"
+    )]
     fn npgettext_fewer_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are few \"UwU\" in text! {}"
         );
     }
 
-
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn gettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
-        assert_eq!(
-            gettext!("Hello, {}!", "World", "UwU"),
-            "Hello, World!"
-        );
+        assert_eq!(gettext!("Hello, {}!", "World", "UwU"), "Hello, World!");
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn dgettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dgettext!("hellorust",
-                "Hello, {}!", "World", "UwU"),
+            dgettext!("hellorust", "Hello, {}!", "World", "UwU"),
             "Hello, World!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn dcgettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, {}!", "World", "UwU"),
+            dcgettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
+                "Hello, {}!",
+                "World",
+                "UwU"
+            ),
             "Hello, World!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn ngettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
@@ -650,75 +684,97 @@ mod test {
             ngettext!(
                 "There is one \"{}\" in text!",
                 "There are few \"{}\" in text!",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn dngettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one \"{}\" in text!",
                 "There are few \"{}\" in text!",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn dcngettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one \"{}\" in text!",
                 "There are few \"{}\" in text!",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn pgettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            pgettext!("context",
-                "Hello, {}!", "World", "UwU"),
+            pgettext!("context", "Hello, {}!", "World", "UwU"),
             "Hello, World!"
         );
     }
 
     #[test]
-    #[cfg_attr(debug_assertions, should_panic="There are more arguments than format directives")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "There are more arguments than format directives"
+    )]
     fn npgettext_more_arguments_than_parameters() {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one \"{}\" in text!",
                 "There are few \"{}\" in text!",
-                2, "UwU", "OwO"
+                2,
+                "UwU",
+                "OwO"
             ),
             "There are few \"UwU\" in text!"
         );
     }
-
 
     #[test]
     fn ngettext_special_n_formatting() {
@@ -754,7 +810,8 @@ mod test {
             ngettext!(
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are 2 \"UwU\" in text! Only 2!"
         );
@@ -766,7 +823,8 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is {n} apple! Only {n}!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -774,7 +832,8 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 1
@@ -782,7 +841,8 @@ mod test {
             "There is one apple! Only one!"
         );
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -790,10 +850,12 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are 2 \"UwU\" in text! Only 2!"
         );
@@ -805,7 +867,9 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is {n} apple! Only {n}!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -813,7 +877,9 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 1
@@ -821,7 +887,9 @@ mod test {
             "There is one apple! Only one!"
         );
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -829,10 +897,13 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are 2 \"UwU\" in text! Only 2!"
         );
@@ -845,7 +916,8 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is {n} apple! Only {n}!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -853,7 +925,8 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 1
@@ -861,7 +934,8 @@ mod test {
             "There is one apple! Only one!"
         );
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one apple! Only one!",
                 "There are {n} apples! Only {n}!",
                 2
@@ -869,15 +943,16 @@ mod test {
             "There are 2 apples! Only 2!"
         );
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is {n} \"{}\" in text! Only {n}!",
                 "There are {n} \"{}\" in text! Only {n}!",
-                2, "UwU"
+                2,
+                "UwU"
             ),
             "There are 2 \"UwU\" in text! Only 2!"
         );
     }
-
 
     #[test]
     fn gettext_trailing_comma() {
@@ -885,10 +960,7 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
-        assert_eq!(
-            gettext!("Hello, World!",),
-            "Hello, World!"
-        );
+        assert_eq!(gettext!("Hello, World!",), "Hello, World!");
         assert_eq!(
             gettext!("Hello, {}! {}", "World", "UwU",),
             "Hello, World! UwU"
@@ -900,14 +972,9 @@ mod test {
         setlocale(LocaleCategory::LcAll, "en_US.UTF-8");
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
+        assert_eq!(dgettext!("hellorust", "Hello, World!",), "Hello, World!");
         assert_eq!(
-            dgettext!("hellorust",
-                "Hello, World!",),
-            "Hello, World!"
-        );
-        assert_eq!(
-            dgettext!("hellorust",
-                "Hello, {}! {}", "World", "UwU",),
+            dgettext!("hellorust", "Hello, {}! {}", "World", "UwU",),
             "Hello, World! UwU"
         );
     }
@@ -918,13 +985,17 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, World!"),
+            dcgettext!("hellorust", LocaleCategory::LcAll, "Hello, World!"),
             "Hello, World!"
         );
         assert_eq!(
-            dcgettext!("hellorust", LocaleCategory::LcAll,
-                "Hello, {}! {}", "World", "UwU",),
+            dcgettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
+                "Hello, {}! {}",
+                "World",
+                "UwU",
+            ),
             "Hello, World! UwU"
         );
     }
@@ -936,18 +1007,16 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            ngettext!(
-                "There is one result",
-                "There are few results",
-                2,
-            ),
+            ngettext!("There is one result", "There are few results", 2,),
             "There are few results"
         );
         assert_eq!(
             ngettext!(
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO",
+                2,
+                "UwU",
+                "OwO",
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -959,7 +1028,8 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one result",
                 "There are few results",
                 2,
@@ -967,10 +1037,13 @@ mod test {
             "There are few results"
         );
         assert_eq!(
-            dngettext!("hellorust",
+            dngettext!(
+                "hellorust",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO",
+                2,
+                "UwU",
+                "OwO",
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -982,7 +1055,9 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
 
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one result",
                 "There are few results",
                 2,
@@ -990,10 +1065,14 @@ mod test {
             "There are few results"
         );
         assert_eq!(
-            dcngettext!("hellorust", LocaleCategory::LcAll,
+            dcngettext!(
+                "hellorust",
+                LocaleCategory::LcAll,
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO",
+                2,
+                "UwU",
+                "OwO",
             ),
             "There are few \"UwU\" in text! OwO"
         );
@@ -1005,14 +1084,9 @@ mod test {
         bindtextdomain("hellorust", "/usr/local/share/locale").unwrap();
         textdomain("hellorust").unwrap();
 
+        assert_eq!(pgettext!("context", "Hello, World!",), "Hello, World!");
         assert_eq!(
-            pgettext!("context",
-                "Hello, World!",),
-            "Hello, World!"
-        );
-        assert_eq!(
-            pgettext!("context",
-                "Hello, {}! {}", "World", "UwU",),
+            pgettext!("context", "Hello, {}! {}", "World", "UwU",),
             "Hello, World! UwU"
         );
     }
@@ -1024,18 +1098,17 @@ mod test {
         textdomain("hellorust").unwrap();
 
         assert_eq!(
-            npgettext!("context",
-                "There is one result",
-                "There are few results",
-                2,
-            ),
+            npgettext!("context", "There is one result", "There are few results", 2,),
             "There are few results"
         );
         assert_eq!(
-            npgettext!("context",
+            npgettext!(
+                "context",
                 "There is one \"{}\" in text! {}",
                 "There are few \"{}\" in text! {}",
-                2, "UwU", "OwO",
+                2,
+                "UwU",
+                "OwO",
             ),
             "There are few \"UwU\" in text! OwO"
         );


### PR DESCRIPTION
Hi! This time it's nothing radical. These macros have the following improvements:
- Can be used without arguments
- In `dev` build, panics with different messages for situations when there are less/more arguments than format directives
- Can have ~~one~~ `{n}` format directive for including number used as `n` in `ngettext`

Should be tested with both `cargo test` and `cargo test --release`. Tests for situations when there are less/more arguments than format directives do not test if panics happen and in which build profile.

TODO:
- [x] Document `{n}` functionality
- [x] Improve tests for "less/more arguments" panics