### PR TITLE
gettext-sys: specify libdir explicitly, release 0.21.2

### DIFF
--- a/gettext-sys/CHANGELOG.md
+++ b/gettext-sys/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.21.2 - 2021-07-21
+
+### Fixed
+- Build failure on some systems which put libraries into "lib64" directory (#73)
+    (Alexander Batischev)
+
+
+
 ## 0.21.1 - 2021-07-16
 
 ### Changed

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -2,8 +2,8 @@
 name = "gettext-sys"
 description = "Raw FFI bindings for gettext"
 license = "MIT"
-version = "0.21.1"
-authors = ["Brian Olsen <brian@maven-group.org>"]
+version = "0.21.2"
+authors = ["Brian Olsen <brian@maven-group.org>", "Alexander Batischev <eual.jp@gmail.com>"]
 build = "build.rs"
 links = "gettext"
 readme = "README.md"

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -220,6 +220,7 @@ fn main() {
     }
 
     cmd.arg(format!("--prefix={}", &posix_path(&build_dir)));
+    cmd.arg(format!("--libdir={}", &posix_path(&build_dir.join("lib"))));
 
     if target != host && (!target.contains("windows") || !host.contains("windows")) {
         // NOTE GNU terminology


### PR DESCRIPTION
Fixes #73.