### PR TITLE
Enable finding the MinGW libraries in ${MINGW_PREFIX}/sys-root/mingw/lib, as these are often are, in addition to ${MINGW_PREFIX}/lib when cross-compiling using MinGW under Linux

### DIFF
--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -99,8 +99,6 @@ fn main() {
             // FIXME: should pthread support be optional?
             // It is needed by `cargo test` while generating doc
             println!("cargo:rustc-link-lib=dylib=pthread");
-            println!("cargo:include={}/include", &gnu_root);
-            println!("cargo:include={}/sys-root/mingw/include", &gnu_root);
             println!("cargo:include={}/../usr/include", &gnu_root);
             return;
         }

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -99,7 +99,7 @@ fn main() {
             // FIXME: should pthread support be optional?
             // It is needed by `cargo test` while generating doc
             println!("cargo:rustc-link-lib=dylib=pthread");
-            println!("cargo:include={}/../usr/include", &gnu_root);
+            println!("cargo:include={}/include", &gnu_root);
             return;
         }
         // else can't use system gettext on this target

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -93,6 +93,7 @@ fn main() {
             // gettext doesn't come with a pkg-config file
             let gnu_root = get_windows_gnu_root();
             println!("cargo:rustc-link-search=native={}/lib", &gnu_root);
+            println!("cargo:rustc-link-search=native={}/sys-root/mingw/lib", &gnu_root);
             println!("cargo:rustc-link-search=native={}/../usr/lib", &gnu_root);
             println!("cargo:rustc-link-lib=dylib=intl");
             // FIXME: should pthread support be optional?
@@ -270,6 +271,10 @@ fn main() {
     if target.contains("windows") {
         println!(
             "cargo:rustc-link-search=native={}/lib",
+            &get_windows_gnu_root()
+        );
+        println!(
+            "cargo:rustc-link-search=native={}/sys-root/mingw/lib",
             &get_windows_gnu_root()
         );
         println!("cargo:rustc-link-lib=dylib=iconv");

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -99,6 +99,8 @@ fn main() {
             // FIXME: should pthread support be optional?
             // It is needed by `cargo test` while generating doc
             println!("cargo:rustc-link-lib=dylib=pthread");
+            println!("cargo:include={}/include", &gnu_root);
+            println!("cargo:include={}/sys-root/mingw/include", &gnu_root);
             println!("cargo:include={}/../usr/include", &gnu_root);
             return;
         }


### PR DESCRIPTION
This pull request will enable finding the MinGW libraries in `${MINGW_PREFIX}/sys-root/mingw/lib`, as these are often are, in addition to `${MINGW_PREFIX}/lib` when cross-compiling using MinGW under Linux using the `gettext-system` feature of the `gettext-sys` Rust package.

For example, in my cross-compiling setup, takings files from the Fedora MinGW packages, there is:

```bash
$ ls /opt/gtkwin/usr/x86_64-w64-mingw32/
sys-root
$ ls /opt/gtkwin/usr/x86_64-w64-mingw32/sys-root/
mingw
$ ls /opt/gtkwin/usr/x86_64-w64-mingw32/sys-root/mingw/
bin  etc  include  lib  share
```