### PR TITLE
CI: migrate to macOS 11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_test_macos:
     name: "ci/run.sh on macOS"
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
       TERM: dumb


### PR DESCRIPTION
macOS 10.15 is deprecated: https://github.com/actions/virtual-environments/issues/5583