### PR TITLE
Add `getters::getlocale`

### DIFF
--- a/gettext-rs/src/getters.rs
+++ b/gettext-rs/src/getters.rs
@@ -17,6 +17,8 @@ use std::io;
 use std::path::PathBuf;
 use std::ptr;
 
+use super::LocaleCategory;
+
 /// Get currently set message domain.
 ///
 /// If you want to *set* the domain, rather than getting its current value, use
@@ -87,6 +89,25 @@ pub fn domain_directory<T: Into<Vec<u8>>>(domainname: T) -> Result<PathBuf, io::
                     result.to_bytes().to_vec(),
                 )))
             }
+        }
+    }
+}
+
+/// Get currently set locale.
+///
+/// If you want to *set* the locale, rather than getting its current value, use
+/// [`setlocale`][::setlocale].
+///
+/// For more information, see [setlocale(3)][].
+///
+/// [setlocale(3)]: https://www.man7.org/linux/man-pages/man3/setlocale.3.html
+pub fn getlocale(category: LocaleCategory) -> Option<Vec<u8>> {
+    unsafe {
+        let result = ffi::setlocale(category as i32, ptr::null());
+        if result.is_null() {
+            None
+        } else {
+            Some(CStr::from_ptr(result).to_bytes().to_owned())
         }
     }
 }

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -419,6 +419,8 @@ where
 /// `setlocale()` later to set the same local again. `None` means the call failed (the underlying
 /// API doesn't provide any details).
 ///
+/// If you want to *get* the locale, rather than set it, use [`getters::getlocale`].
+///
 /// For more information, see [setlocale(3)][].
 ///
 /// [setlocale(3)]: https://www.man7.org/linux/man-pages/man3/setlocale.3.html


### PR DESCRIPTION
Add a way to get the current active locale by passing in a null pointer
to the C `setlocale` function, which is documented to be the way to
query the locale; without this, there is no way for users of this
library to query the current locale.