### PR TITLE
Fix system detection when cross-compiling with Yocto

### DIFF
--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -86,7 +86,7 @@ fn main() {
     let target = env::var("TARGET").unwrap();
 
     if cfg!(feature = "gettext-system") || env("GETTEXT_SYSTEM").is_some() {
-        if target.contains("linux") && (target.contains("-gnu") || target.contains("-musl")) {
+        if env::var("CARGO_CFG_TARGET_OS") == Ok("linux".to_string()) {
             // intl is part of glibc and musl
             return;
         } else if target.contains("windows") && target.contains("-gnu") {


### PR DESCRIPTION
In Yocto the target can be for example aarch63-poky-linux, which is most definitely gnu, but doesn't contain the gnu infix in the target.

Instead, detect Linux using CARGO_CFG_TARGET_OS and assume that it's gnu or musl.