### PR TITLE
Make gettext-sys no_std

### DIFF
--- a/gettext-sys/lib.rs
+++ b/gettext-sys/lib.rs
@@ -1,4 +1,6 @@
-use std::os::raw::{c_char, c_int, c_ulong};
+#![no_std]
+
+use core::ffi::{c_char, c_int, c_ulong};
 
 #[cfg(windows)]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
Switches the C types from `std::os::raw` to `core::ffi` - this does have the consequence of bumping the minimum Rust version from Rust 1.1 to Rust 1.30 