### PR TITLE
Fix the locale codes

### DIFF
--- a/gettext-rs/Cargo.toml
+++ b/gettext-rs/Cargo.toml
@@ -22,6 +22,7 @@ version = "0.21.0"
 path = "../gettext-sys"
 
 [dependencies]
+cfg-if = "1"
 locale_config = "0.3"
 
 [dev-dependencies]

--- a/gettext-rs/src/lc_codes.rs
+++ b/gettext-rs/src/lc_codes.rs
@@ -1,0 +1,68 @@
+cfg_if::cfg_if! {
+    if #[cfg(all(unix,
+                 any(target_os = "linux",
+                     target_os = "l4re",
+                     target_os = "android",
+                     target_os = "emscripten"),
+                 any(target_env = "ohos",
+                     target_env = "gnu",
+                     target_os = "android")))] {
+        /// Locale category enum ported from locale.h.
+        #[derive(Debug, PartialEq, Clone, Copy)]
+        pub enum LocaleCategory {
+            /// Character classification and case conversion.
+            LcCType = ffi::LC_CTYPE as isize,
+            /// Non-monetary numeric formats.
+            LcNumeric = ffi::LC_NUMERIC as isize,
+            /// Date and time formats.
+            LcTime = ffi::LC_TIME as isize,
+            /// Collation order.
+            LcCollate = ffi::LC_COLLATE as isize,
+            /// Monetary formats.
+            LcMonetary = ffi::LC_MONETARY as isize,
+            /// Formats of informative and diagnostic messages and interactive responses.
+            /// `setlocale()` will treat this as `LcAll` on non-POSIX systems.
+            LcMessages = ffi::LC_MESSAGES as isize,
+            /// For all.
+            LcAll = ffi::LC_ALL as isize,
+            /// Paper size.
+            /// Only supported on Linux-like operating systems.
+            LcPaper = ffi::LC_PAPER as isize,
+            /// Name formats.
+            /// Only supported on Linux-like operating systems.
+            LcName = ffi::LC_NAME as isize,
+            /// Address formats and location information.
+            /// Only supported on Linux-like operating systems.
+            LcAddress = ffi::LC_ADDRESS as isize,
+            /// Telephone number formats.
+            /// Only supported on Linux-like operating systems.
+            LcTelephone = ffi::LC_TELEPHONE as isize,
+            /// Measurement units (Metric or Other).
+            /// Only supported on Linux-like operating systems.
+            LcMeasurement = ffi::LC_MEASUREMENT as isize,
+            /// Metadata about the locale information.
+            /// Only supported on Linux-like operating systems.
+            LcIdentification = ffi::LC_IDENTIFICATION as isize,
+        }
+    } else {
+        /// Locale category enum ported from locale.h.
+        #[derive(Debug, PartialEq, Clone, Copy)]
+        pub enum LocaleCategory {
+            /// Character classification and case conversion.
+            LcCType = ffi::LC_CTYPE as isize,
+            /// Non-monetary numeric formats.
+            LcNumeric = ffi::LC_NUMERIC as isize,
+            /// Date and time formats.
+            LcTime = ffi::LC_TIME as isize,
+            /// Collation order.
+            LcCollate = ffi::LC_COLLATE as isize,
+            /// Monetary formats.
+            LcMonetary = ffi::LC_MONETARY as isize,
+            /// Formats of informative and diagnostic messages and interactive responses.
+            /// `setlocale` will treat this as `LcAll` on non-POSIX systems.
+            LcMessages = ffi::LC_MESSAGES as isize,
+            /// For all.
+            LcAll = ffi::LC_ALL as isize,
+        }
+    }
+}

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -19,6 +19,13 @@ path = "lib.rs"
 [features]
 gettext-system = []
 
+[dependencies.libc]
+version = "0.2"
+default-features = false
+
+[dependencies]
+cfg-if = "1"
+
 [build-dependencies]
 cc = "1.0"
 temp-dir = "0.1.11"

--- a/gettext-sys/gettext_exports.rs
+++ b/gettext-sys/gettext_exports.rs
@@ -1,0 +1,41 @@
+use std::os::raw::{c_char, c_int, c_ulong};
+
+#[cfg(windows)]
+#[allow(non_camel_case_types)]
+type wchar_t = u16;
+
+extern "C" {
+    pub fn gettext(s: *const c_char) -> *mut c_char;
+    pub fn dgettext(domain: *const c_char, s: *const c_char) -> *mut c_char;
+    pub fn dcgettext(domain: *const c_char, s: *const c_char, category: c_int) -> *mut c_char;
+
+    pub fn ngettext(s1: *const c_char, s2: *const c_char, n: c_ulong) -> *mut c_char;
+    pub fn dngettext(
+        domain: *const c_char,
+        s1: *const c_char,
+        s2: *const c_char,
+        n: c_ulong,
+    ) -> *mut c_char;
+    pub fn dcngettext(
+        domain: *const c_char,
+        s1: *const c_char,
+        s2: *const c_char,
+        n: c_ulong,
+        category: c_int,
+    ) -> *mut c_char;
+
+    pub fn bindtextdomain(domain: *const c_char, dir: *const c_char) -> *mut c_char;
+    #[cfg(windows)]
+    // The "wbindtextdomain" symbol is not exposed directly in the compiled
+    // .DLL file when building using MinGW. See: https://github.com/Koka/gettext-rs/pull/79
+    pub fn libintl_wbindtextdomain(domain: *const c_char, dir: *const wchar_t) -> *mut wchar_t;
+
+    pub fn textdomain(domain: *const c_char) -> *mut c_char;
+
+    pub fn bind_textdomain_codeset(domain: *const c_char, codeset: *const c_char) -> *mut c_char;
+}
+
+#[cfg(windows)]
+pub unsafe fn wbindtextdomain(domain: *const c_char, dir: *const wchar_t) -> *mut wchar_t {
+    libintl_wbindtextdomain(domain, dir)
+}

--- a/gettext-sys/lc_codes.rs
+++ b/gettext-sys/lc_codes.rs
@@ -1,0 +1,36 @@
+pub use libc::LC_CTYPE;
+pub use libc::LC_NUMERIC;
+pub use libc::LC_TIME;
+pub use libc::LC_COLLATE;
+pub use libc::LC_MONETARY;
+pub use libc::LC_ALL;
+
+cfg_if::cfg_if!{
+    if #[cfg(all(unix,
+                 any(target_os = "linux",
+                     target_os = "l4re",
+                     target_os = "android",
+                     target_os = "emscripten"),
+                 any(target_env = "ohos",
+                     target_env = "gnu",
+                     target_os = "android")))] {
+        pub use libc::LC_MESSAGES;
+        pub use libc::LC_NAME;
+        pub use libc::LC_ADDRESS;
+        pub use libc::LC_TELEPHONE;
+        pub use libc::LC_MEASUREMENT;
+        pub use libc::LC_IDENTIFICATION;
+
+        pub const LIBC_HAS_LC_MESSAGES: bool = true;
+    } else if #[cfg(any(target_os = "fuchsia",
+                        target_os = "solid_asp3",
+                        all(unix, not(target_os = "hermit"))))] {
+        pub use libc::LC_MESSAGES;
+
+        pub const LIBC_HAS_LC_MESSAGES: bool = true;
+    } else {
+        pub const LC_MESSAGES: c_int = 1729;
+
+        pub const LIBC_HAS_LC_MESSAGES: bool = false;
+    }
+}

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -22,7 +22,7 @@ fn main() {
         cfg.skip_fn_ptrcheck(|_| true);
     }
 
-    cfg.generate("../gettext-sys/lib.rs", "all.rs");
+    cfg.generate("../gettext-sys/gettext_exports.rs", "all.rs");
 
     // Check that we can find and run gettext binary
     let cmd = if let Some(bin) = env::var_os("DEP_GETTEXT_BIN") {

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,4 +1,6 @@
 #![allow(bad_style)]
+#![allow(unused_imports)]
+#![allow(unused_macros)]
 
 extern crate gettext_sys;
 


### PR DESCRIPTION
Resolves #107 

Since the values of the various `LC_` constants vary from system to system, get them from libc instead of hardcoding particular values.

Furthermore, since some systems (e.g. Windows) do not have `LC_MESSAGES`, use the libintl.h fallback value of 1729 on these systems and treat it as `LC_ALL` when passed to `setlocale()`.

Also fixes a couple of unused import/macro warnings in the tests, plus allows them to build on Windows since the symbol 