### PR TITLE
CI: disable Musl builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,11 +28,12 @@ jobs:
               TARGET: i686-unknown-linux-gnu
               DOCKER: linux32
             name: "i686, Rust stable"
-          - rust-version: stable
-            env:
-              TARGET: x86_64-unknown-linux-musl
-              DOCKER: musl
-            name: "x86_64 with musl, Rust stable"
+          # See https://github.com/Koka/gettext-rs/issues/99 for why this is disabled
+          #- rust-version: stable
+          #  env:
+          #    TARGET: x86_64-unknown-linux-musl
+          #    DOCKER: musl
+          #  name: "x86_64 with musl, Rust stable"
           - rust-version: stable
             env:
               TARGET: x86_64-unknown-linux-gnu


### PR DESCRIPTION
Tests segfault since Rust 1.62.0, so I'm disabling them to make progress on other PRs. See #99.