### PR TITLE
CI: update to Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_test_linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
       TERM: dumb

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
Ubuntu 18.04 is no longer available with GitHub-hosted runners, so the Linux workflow didn't even run anymore.