### PR TITLE
Allow use of glibc/libintl on GNU/Hurd

### DIFF
--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -97,6 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ```
         pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc libxml2-devel tar
         ```
+    * GNU/Hurd with glibc;
 
     If none of those conditions hold, the crate will proceed to building and
     statically linking its own copy of GNU gettext!

--- a/gettext-sys/README.md
+++ b/gettext-sys/README.md
@@ -26,6 +26,7 @@ abide by LGPL**. If you don't want or can't do that, there are two ways out:
         pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc libxml2-devel tar
         ```
     * FreeBSD with GNU gettext installed as a package or port;
+    * GNU/Hurd with glibc;
 
     If none of those conditions hold, the crate will proceed to building and
     statically linking its own copy of GNU gettext!

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -101,7 +101,9 @@ fn try_gettext_system() -> bool {
     let target = env::var("TARGET").unwrap();
 
     if cfg!(feature = "gettext-system") || env("GETTEXT_SYSTEM").is_some() {
-        if target.contains("linux") && (target.contains("-gnu") || target.contains("-musl")) {
+        if (target.contains("linux") || target.contains("hurd"))
+            && (target.contains("-gnu") || target.contains("-musl"))
+        {
             // intl is part of glibc and musl
             return true;
         } else if target.contains("windows") && target.contains("-gnu") {


### PR DESCRIPTION
GNU/Hurd uses GNU libc, which ships libintl; hence, when building using a system gettext installation on the Hurd, there is nothing else to do.

Advertize this new support in the READMEs of the crates.