### PR TITLE
Bump gettext-sys to 0.23.2, gettext-rs to 0.7.4

### DIFF
--- a/gettext-rs/CHANGELOG.md
+++ b/gettext-rs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.4 - 2025-10-10
+
+## Changed
+
+- Allow gettext-sys 0.23
+
+
+
 ## 0.7.3 - 2025-10-10
 
 ### Added

--- a/gettext-rs/Cargo.toml
+++ b/gettext-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gettext-rs"
 description = "Safe bindings for gettext"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Konstantin Salikhov <koka58@yandex.ru>", "Alexander Batischev <eual.jp@gmail.com>"]
 repository = "https://github.com/gettext-rs/gettext-rs"
 documentation = "https://docs.rs/gettext-rs/"
@@ -18,7 +18,7 @@ name = "gettextrs"
 gettext-system = ["gettext-sys/gettext-system"]
 
 [dependencies.gettext-sys]
-version = ">= 0.21.0, <0.23.0"
+version = ">= 0.21.0, <0.24.0"
 path = "../gettext-sys"
 
 [dependencies]

--- a/gettext-sys/CHANGELOG.md
+++ b/gettext-sys/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.23.0 - 2025-10-10
+
+Please note that in macOS 15 the `iconv()` call is too broken to be used by GNU
+gettext; see the upstream bug: https://savannah.gnu.org/bugs/index.php?66541
+
+### Changed
+
+- Bump bundled GNU gettext to 0.23.2 (Alexander Batischev)
+
+
+
 ## 0.22.6 - 2025-10-10
 
 ### Added

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gettext-sys"
 description = "Raw FFI bindings for gettext"
 license = "MIT"
-version = "0.22.6"
+version = "0.23.0"
 authors = ["Brian Olsen <brian@maven-group.org>", "Alexander Batischev <eual.jp@gmail.com>"]
 build = "build.rs"
 links = "gettext"

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -225,7 +225,7 @@ fn prepare_cflags(target: &str, compiler: &cc::Tool) -> OsString {
 
 fn unpack_tarball(src: &Path, build_dir: &Path) {
     let xzcat = Command::new("xzcat")
-        .arg(&src.join("gettext-0.22.5.tar.xz"))
+        .arg(&src.join("gettext-0.23.2.tar.xz"))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .spawn()
@@ -266,7 +266,7 @@ fn run_configure(target: &str, compiler: &cc::Tool, build_dir: &Path) {
         .arg(&posix_path(
             &build_dir
                 .join("gettext")
-                .join("gettext-0.22.5")
+                .join("gettext-0.23.2")
                 .join("gettext-runtime")
                 .join("configure"),
         ));


### PR DESCRIPTION
https://savannah.gnu.org/news/?id=10699

Releases will be made later, I'm currently waiting on:
- confirmation that #116 works on OpenBSD
- an update to #131