### PR TITLE
Fix iterator lifetime error on nightly

### DIFF
--- a/gettext-rs/src/text_domain.rs
+++ b/gettext-rs/src/text_domain.rs
@@ -345,7 +345,7 @@ impl TextDomain {
         let sys_data_dirs_iter = env::split_paths(&sys_data_paths_str);
 
         // Chain search paths and search for the translation mo file
-        self.pre_paths
+        let locale_set = self.pre_paths
             .into_iter()
             .chain(sys_data_dirs_iter)
             .chain(self.post_paths.into_iter())
@@ -388,7 +388,9 @@ impl TextDomain {
                     .map_err(TextDomainError::BindTextDomainCodesetCallFailed)?;
                 textdomain(domainname).map_err(TextDomainError::TextDomainCallFailed)?;
                 Ok(result)
-            })
+            });
+
+        locale_set
     }
 }
 

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -385,9 +385,11 @@ fn fail(s: &str) -> ! {
 fn which(cmd: &str) -> Option<PathBuf> {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
     let paths = env::var_os("PATH").unwrap();
-    env::split_paths(&paths)
+    let path = env::split_paths(&paths)
         .map(|p| p.join(&cmd))
-        .find(|p| fs::metadata(p).is_ok())
+        .find(|p| fs::metadata(p).is_ok());
+
+    path
 }
 
 fn make() -> Command {


### PR DESCRIPTION
It looks like nightly has gotten more strict around iterator lifetimes. This fixes two cases that are necessary for compilation to succeed.