### PR TITLE
gettext-sys: support cygwin system libs

### DIFF
--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -121,6 +121,9 @@ fn try_gettext_system() -> bool {
             println!("cargo:rustc-link-search=native=/usr/local/lib");
             println!("cargo:rustc-link-lib=dylib=intl");
             return true;
+        } else if target.contains("cygwin") {
+            println!("cargo:rustc-link-lib=dylib=intl");
+            return true;
         }
         // else can't use system gettext on this target
     }


### PR DESCRIPTION
There are two distributions of cygwin. The official cygwin `libintl-devel` contains `/usr/lib/libintl.a`, and MSYS2 `gettext-devel` contains `/usr/lib/libintl.a`, too.