### PR TITLE
gettext-sys: build just the library

### DIFF
--- a/ci/Dockerfile-linux64-build
+++ b/ci/Dockerfile-linux64-build
@@ -7,11 +7,11 @@ RUN apt-get install -y --no-install-recommends \
 ENV GETTEXT_VERSION 0.19.8.1
 RUN curl -sL https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.gz -o gettext-${GETTEXT_VERSION}.tar.gz && \
     tar -xf gettext-${GETTEXT_VERSION}.tar.gz && \
-    cd gettext-${GETTEXT_VERSION} && \
+    cd gettext-${GETTEXT_VERSION}/gettext-runtime && \
     ./configure --without-emacs --disable-java --disable-c++ --enable-fast-install --prefix=/result \
       --disable-csharp --enable-static --with-included-gettext --with-included-glib \
       --with-included-libcroco --with-included-libunistring && \
     make -j2 && \
     make install && \
-    cd .. && \
+    cd ../.. && \
     rm -rf gettext-${GETTEXT_VERSION} gettext-${GETTEXT_VERSION}.tar.gz

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -267,6 +267,7 @@ fn run_configure(target: &str, compiler: &cc::Tool, build_dir: &Path) {
             &build_dir
                 .join("gettext")
                 .join("gettext-0.22.5")
+                .join("gettext-runtime")
                 .join("configure"),
         ));
 


### PR DESCRIPTION
Kudos to Bruno Haible for the hint.

Resolves #138.