### PR TITLE
ci: add MSYS2

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,35 @@
+name: Build & test on MSYS2
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 6" # At 00:00 every Saturday
+
+jobs:
+  build_and_test_msys2:
+    name: "ci/run.sh on MSYS2"
+    runs-on: windows-latest
+    env:
+      # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
+      TERM: dumb
+      GETTEXT_SYSTEM: 1
+      TARGET: x86_64-pc-cygwin
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          install: gettext-devel rust
+          update: true
+          release: false
+
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: ./ci/run.sh
+        shell: msys2 {0}
+        run: sh ci/run.sh

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -9,4 +9,4 @@ build = "build.rs"
 gettext-sys = { path = "../gettext-sys" }
 
 [build-dependencies]
-ctest2 = "0.4"
+ctest = "0.4"

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,11 +1,11 @@
-extern crate ctest2;
+extern crate ctest;
 
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
 fn main() {
-    let mut cfg = ctest2::TestGenerator::new();
+    let mut cfg = ctest::TestGenerator::new();
 
     let target = env::var("TARGET").unwrap();
     if target.contains("freebsd") {

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -22,7 +22,10 @@ fn main() {
     // Skip ptr check because the symbol name is different between glibc
     // implementation and static lib.
     // eg. gettext is libintl_gettext in static lib
-    if env::var_os("GETTEXT_SYSTEM").is_none() || target.contains("windows") || target.contains("cygwin") {
+    if env::var_os("GETTEXT_SYSTEM").is_none()
+        || target.contains("windows")
+        || target.contains("cygwin")
+    {
         println!("Skipping ptr check");
         cfg.skip_fn_ptrcheck(|_| true);
     }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -22,7 +22,7 @@ fn main() {
     // Skip ptr check because the symbol name is different between glibc
     // implementation and static lib.
     // eg. gettext is libintl_gettext in static lib
-    if env::var_os("GETTEXT_SYSTEM").is_none() || env::var("TARGET").unwrap().contains("windows") {
+    if env::var_os("GETTEXT_SYSTEM").is_none() || target.contains("windows") || target.contains("cygwin") {
         println!("Skipping ptr check");
         cfg.skip_fn_ptrcheck(|_| true);
     }


### PR DESCRIPTION
* Use `ctest`.
* Skip ptr check because the symbol name are always prefixed with `libintl_` when building C codes (same as MinGW).