### PR TITLE
Update bundled GNU gettext to 1.0

### DIFF
--- a/gettext-rs/Cargo.toml
+++ b/gettext-rs/Cargo.toml
@@ -18,7 +18,7 @@ name = "gettextrs"
 gettext-system = ["gettext-sys/gettext-system"]
 
 [dependencies.gettext-sys]
-version = ">= 0.21.0, <0.27.0"
+version = ">= 0.21.0, <1.1.0"
 path = "../gettext-sys"
 
 [dependencies]

--- a/gettext-sys/Cargo.toml
+++ b/gettext-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gettext-sys"
 description = "Raw FFI bindings for gettext"
 license = "MIT"
-version = "0.26.0"
+version = "1.0.0"
 authors = ["Brian Olsen <brian@maven-group.org>", "Alexander Batischev <eual.jp@gmail.com>"]
 build = "build.rs"
 links = "gettext"

--- a/gettext-sys/build.rs
+++ b/gettext-sys/build.rs
@@ -228,7 +228,7 @@ fn prepare_cflags(target: &str, compiler: &cc::Tool) -> OsString {
 
 fn unpack_tarball(src: &Path, build_dir: &Path) {
     let xzcat = Command::new("xzcat")
-        .arg(&src.join("gettext-0.26.tar.xz"))
+        .arg(&src.join("gettext-1.0.tar.xz"))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .spawn()
@@ -269,7 +269,7 @@ fn run_configure(target: &str, compiler: &cc::Tool, build_dir: &Path) {
         .arg(&posix_path(
             &build_dir
                 .join("gettext")
-                .join("gettext-0.26")
+                .join("gettext-1.0")
                 .join("gettext-runtime")
                 .join("configure"),
         ));
@@ -284,6 +284,7 @@ fn run_configure(target: &str, compiler: &cc::Tool, build_dir: &Path) {
     cmd.arg("--with-included-gettext");
     cmd.arg("--with-included-glib");
     cmd.arg("--with-included-libcroco");
+    cmd.arg("--with-included-libintl");
     cmd.arg("--with-included-libunistring");
 
     if target.contains("windows") {


### PR DESCRIPTION
I won't cut a release right away because I'd like to take this opportunity to rework the `gettext-system` Cargo feature.