### PR TITLE
CI: update actions that use Node 20

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,13 +96,13 @@ jobs:
         if: ${{ ! matrix.env.NO_ADD }}
 
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate lockfile
         run: cargo generate-lockfile
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ hashFiles('**/Cargo.lock') }}
           path: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,13 +50,13 @@ jobs:
         run: echo '::remove-matcher owner=cargo-test::'
 
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate lockfile
         run: cargo generate-lockfile
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ hashFiles('**/Cargo.lock') }}
           path: |

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -28,7 +28,7 @@ jobs:
           release: false
 
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ./ci/run.sh
         shell: msys2 {0}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,6 +13,6 @@ jobs:
           rust-version: stable
 
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - run: cargo fmt --all -- --check


### PR DESCRIPTION
Node 20 is getting deprecated by GitHub:

> Node.js 20 actions are deprecated. The following actions are running
> on Node.js 20 and may not work as expected: actions/cache@v4,
> actions/checkout@v4. Actions will be forced to run with Node.js 24 by
> default starting June 2nd, 2026. Node.js 20 will be removed from the
> runner on September 16th